### PR TITLE
Potential fix for code scanning alert no. 1: Potentially unsafe quoting

### DIFF
--- a/internal/workout/models.go
+++ b/internal/workout/models.go
@@ -36,53 +36,54 @@ func (ejs exerciseJSONSchema) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("marshal muscle groups: %w", err)
 	}
 
-	return []byte(fmt.Sprintf(`{
-		  "type": "object",
-		  "required": [
+	schema := map[string]interface{}{
+		"type": "object",
+		"required": []string{
 			"id",
 			"name",
 			"category",
 			"description_markdown",
 			"primary_muscle_groups",
-			"secondary_muscle_groups"
-		  ],
-		  "properties": {
-			"id": {
-			  "type": "integer",
-			  "description": "Unique identifier for the exercise, leave as -1 for new exercises"
+			"secondary_muscle_groups",
+		},
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{
+				"type":        "integer",
+				"description": "Unique identifier for the exercise, leave as -1 for new exercises",
 			},
-			"name": {
-			  "type": "string",
-			  "description": "Name of the exercise"
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Name of the exercise",
 			},
-			"category": {
-			  "type": "string",
-			  "description": "Category of the exercise",
-			  "enum": ["full_body", "upper", "lower"]
+			"category": map[string]interface{}{
+				"type":        "string",
+				"description": "Category of the exercise",
+				"enum":        []string{"full_body", "upper", "lower"},
 			},
-			"description_markdown": {
-			  "type": "string",
-			  "description": "Markdown description of the exercise"
+			"description_markdown": map[string]interface{}{
+				"type":        "string",
+				"description": "Markdown description of the exercise",
 			},
-			"primary_muscle_groups": {
-			  "type": "array",
-			  "description": "Primary muscle groups targeted by the exercise",
-			  "items": {
-				"type": "string",
-				"enum": %s
-			  }
+			"primary_muscle_groups": map[string]interface{}{
+				"type":        "array",
+				"description": "Primary muscle groups targeted by the exercise",
+				"items": map[string]interface{}{
+					"type": "string",
+					"enum": ejs.muscleGroups,
+				},
 			},
-			"secondary_muscle_groups": {
-			  "type": "array",
-			  "description": "Secondary muscle groups targeted by the exercise",
-			  "items": {
-				"type": "string",
-				"enum": %s
-			  }
-			}
-		  },
-		  "additionalProperties": false
-		}`, muscleGroupsJSON, muscleGroupsJSON)), nil
+			"secondary_muscle_groups": map[string]interface{}{
+				"type":        "array",
+				"description": "Secondary muscle groups targeted by the exercise",
+				"items": map[string]interface{}{
+					"type": "string",
+					"enum": ejs.muscleGroups,
+				},
+			},
+		},
+		"additionalProperties": false,
+	}
+	return json.Marshal(schema)
 }
 
 // Set represents a single set of an exercise with target and actual performance.

--- a/internal/workout/models.go
+++ b/internal/workout/models.go
@@ -30,12 +30,6 @@ type exerciseJSONSchema struct {
 }
 
 func (ejs exerciseJSONSchema) MarshalJSON() ([]byte, error) {
-	// encode the muscle groups into the JSON schema
-	muscleGroupsJSON, err := json.Marshal(ejs.muscleGroups)
-	if err != nil {
-		return nil, fmt.Errorf("marshal muscle groups: %w", err)
-	}
-
 	schema := map[string]interface{}{
 		"type": "object",
 		"required": []string{
@@ -83,7 +77,11 @@ func (ejs exerciseJSONSchema) MarshalJSON() ([]byte, error) {
 		},
 		"additionalProperties": false,
 	}
-	return json.Marshal(schema)
+	result, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal exercise schema: %w", err)
+	}
+	return result, nil
 }
 
 // Set represents a single set of an exercise with target and actual performance.


### PR DESCRIPTION
Potential fix for [https://github.com/myrjola/petrapp/security/code-scanning/1](https://github.com/myrjola/petrapp/security/code-scanning/1)

To fix the problem, we should avoid manually constructing the JSON string and instead use a structured approach to ensure that all data is properly escaped and embedded. We can achieve this by creating a map or struct that represents the entire JSON schema and then marshaling it into a JSON string. This approach ensures that all data, including `muscleGroupsJSON`, is correctly escaped.

1. Create a struct or map that represents the entire JSON schema.
2. Populate the struct or map with the necessary data, including `muscleGroupsJSON`.
3. Marshal the struct or map into a JSON string using `json.Marshal`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
