### PR TITLE
feat: add flight recorder for request timeout traces [skip-review]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,13 +2,13 @@ name: Claude Code
 
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
   pull_request_review_comment:
-    types: [created]
+    types: [ created ]
   issues:
-    types: [opened, assigned]
+    types: [ opened, assigned ]
   pull_request_review:
-    types: [submitted]
+    types: [ submitted ]
 
 jobs:
   claude:

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ node_modules
 # Database files
 *.sqlite*
 
+# Trace files
+/traces/
+
 # Temporary files
 /tmp
 /test-results/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ fly deploy
 
 ### Performance investigation
 
+#### pprof
+
 Use [pprof](https://pkg.go.dev/net/http/pprof) for perfomance investigation.
 
 Proxy the pprof server to your local machine.
@@ -92,6 +94,37 @@ Capture a goroutine stack traces.
 
 ```sh
 go tool pprof -top "http://localhost:6060/debug/pprof/goroutine"
+```
+
+#### Flight Controller for automatic trace capture
+
+When a request times out, the app writes a [trace](https://pkg.go.dev/runtime/trace) to a file and logs something like the following line: 
+
+```json
+{
+  "time": "2025-09-13T10:02:11.604995985+03:00",
+  "level": "WARN",
+  "msg": "captured timeout trace",
+  "service_name": "pr-29-myrjola-petrapp",
+  "file": "/data/traces/timeout-20250913-070211.trace",
+  "bytes": 709652,
+  "trace_id": "HBGYTREFLURSGLEQGR2OX4XEBK",
+  "proto": "HTTP/1.1",
+  "method": "GET",
+  "uri": "/api/test/timeout?sleep_ms=3000"
+}
+```
+
+This file can be downloaded with the following replacing FLY_APP and file name with service_name and file from the log line:
+
+```
+FLY_APP=pr-29-myrjola-petrapp fly sftp get /data/traces/timeout-20250913-070211.trace
+```
+
+Once you have the file, you can analyze it with:
+
+```
+go tool trace timeout-20250913-070211.trace
 ```
 
 ### CI/CD and preview environments

--- a/cmd/web/handler-admin-exercises_test.go
+++ b/cmd/web/handler-admin-exercises_test.go
@@ -16,11 +16,10 @@ func Test_application_adminExercises(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 

--- a/cmd/web/handler-admin-feature-flags_test.go
+++ b/cmd/web/handler-admin-feature-flags_test.go
@@ -15,11 +15,10 @@ func Test_application_adminFeatureFlags(t *testing.T) {
 		ctx = t.Context()
 		doc *goquery.Document
 	)
-	server, err := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 
@@ -100,11 +99,10 @@ func Test_application_maintenanceMode_integration(t *testing.T) {
 	var (
 		ctx = t.Context()
 	)
-	server, err := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 
@@ -127,7 +125,7 @@ func Test_application_maintenanceMode_integration(t *testing.T) {
 
 	t.Run("Regular user sees maintenance page when enabled", func(t *testing.T) {
 		// Create a new client without admin privileges
-		nonAdminServer, serverErr := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+		nonAdminServer, serverErr := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 		if serverErr != nil {
 			t.Fatalf("Failed to start non-admin server: %v", serverErr)
 		}
@@ -220,7 +218,7 @@ func Test_application_maintenanceMode_integration(t *testing.T) {
 
 	t.Run("Authentication APIs bypass maintenance mode", func(t *testing.T) {
 		// Create a new client without admin privileges to test auth API access
-		nonAdminServer, serverErr := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+		nonAdminServer, serverErr := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 		if serverErr != nil {
 			t.Fatalf("Failed to start non-admin server: %v", serverErr)
 		}
@@ -272,7 +270,7 @@ func Test_application_maintenanceMode_integration(t *testing.T) {
 
 	t.Run("Static files bypass maintenance mode", func(t *testing.T) {
 		// Create a new client without admin privileges to test static file access
-		nonAdminServer, serverErr := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+		nonAdminServer, serverErr := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 		if serverErr != nil {
 			t.Fatalf("Failed to start non-admin server: %v", serverErr)
 		}
@@ -312,7 +310,7 @@ func Test_application_maintenanceMode_integration(t *testing.T) {
 		}
 
 		// Create a new client without admin privileges
-		nonAdminServer, serverErr := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+		nonAdminServer, serverErr := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 		if serverErr != nil {
 			t.Fatalf("Failed to start non-admin server: %v", serverErr)
 		}

--- a/cmd/web/handler-exercies-info_test.go
+++ b/cmd/web/handler-exercies-info_test.go
@@ -17,11 +17,10 @@ func Test_application_exerciseInfo(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 

--- a/cmd/web/handler-exerciseset_test.go
+++ b/cmd/web/handler-exerciseset_test.go
@@ -17,11 +17,10 @@ func Test_application_exerciseSet(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 

--- a/cmd/web/handler-home_test.go
+++ b/cmd/web/handler-home_test.go
@@ -28,11 +28,10 @@ func Test_application_home(t *testing.T) {
 		ctx = t.Context()
 		doc *goquery.Document
 	)
-	server, err := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 
@@ -87,11 +86,10 @@ func checkButtonPresence(t *testing.T, doc *goquery.Document, buttonText string,
 
 func Test_crossOriginProtection(t *testing.T) {
 	ctx := t.Context()
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	// Create a malicious client that simulates cross-origin requests
 	maliciousClient, err := e2etest.NewClientWithSecFetchSite(

--- a/cmd/web/handler-home_test.go
+++ b/cmd/web/handler-home_test.go
@@ -16,6 +16,8 @@ func testLookupEnv(key string) (string, bool) {
 		return ":memory:", true
 	case "PETRAPP_ADDR":
 		return "localhost:0", true
+	case "PETRAPP_TRACES_DIRECTORY":
+		return "", true // Use default (empty string means use module root)
 	default:
 		return "", false
 	}

--- a/cmd/web/handler-notfound_test.go
+++ b/cmd/web/handler-notfound_test.go
@@ -15,11 +15,10 @@ func Test_application_notFound(t *testing.T) {
 		ctx = t.Context()
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 
@@ -164,11 +163,10 @@ func Test_application_notFound_template_content(t *testing.T) {
 		doc *goquery.Document
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 

--- a/cmd/web/handler-preferences_test.go
+++ b/cmd/web/handler-preferences_test.go
@@ -25,11 +25,10 @@ func Test_application_preferences(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 
@@ -137,7 +136,7 @@ func Test_application_exportUserData(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
@@ -272,11 +271,10 @@ func Test_application_deleteUser(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(t.Context(), testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 

--- a/cmd/web/handler-workout_test.go
+++ b/cmd/web/handler-workout_test.go
@@ -17,11 +17,10 @@ func Test_application_addWorkout(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 
@@ -90,11 +89,10 @@ func Test_application_workoutNotFound(t *testing.T) {
 		err error
 	)
 
-	server, err := e2etest.StartServer(ctx, testhelpers.NewWriter(t), testLookupEnv, run)
+	server, err := e2etest.StartServer(t, testhelpers.NewWriter(t), testLookupEnv, run)
 	if err != nil {
 		t.Fatalf("Failed to start server: %v", err)
 	}
-	t.Cleanup(server.Shutdown)
 
 	client := server.Client()
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -124,7 +124,7 @@ func run(ctx context.Context, logger *slog.Logger, lookupEnv func(string) (strin
 		return fmt.Errorf("initialize routes: %w", err)
 	}
 
-	return app.startAndWaitForShutdown(ctx, cfg.Addr, routes)
+	return app.configureAndStartServer(ctx, cfg.Addr, routes)
 }
 
 func initializeSessionManager(dbs *sqlite.Database) *scs.SessionManager {

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"log/slog"
@@ -202,6 +203,7 @@ func (app *application) crossOriginProtection(next http.Handler) http.Handler {
 
 // timeout times out the request and cancels the context using http.TimeoutHandler.
 // Admins get a longer timeout so that they can call external services.
+// Captures flight recorder traces when requests timeout.
 func (app *application) timeout(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc := http.NewResponseController(w)
@@ -214,7 +216,53 @@ func (app *application) timeout(next http.Handler) http.Handler {
 				return
 			}
 		}
-		http.TimeoutHandler(next, timeout, "timed out").ServeHTTP(w, r)
+
+		// Create a custom timeout handler that captures traces on timeout.
+		timeoutHandler := app.createTimeoutHandlerWithTracing(next, timeout, r.Method, r.URL.Path)
+		timeoutHandler.ServeHTTP(w, r)
+	})
+}
+
+// createTimeoutHandlerWithTracing creates a timeout handler that captures flight recorder
+// traces when a timeout occurs.
+func (app *application) createTimeoutHandlerWithTracing(
+	next http.Handler, timeout time.Duration, method, path string,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+
+		done := make(chan struct{})
+		panicChan := make(chan interface{}, 1)
+
+		go func() {
+			defer func() {
+				if p := recover(); p != nil {
+					panicChan <- p
+				}
+			}()
+
+			r = r.WithContext(ctx)
+			next.ServeHTTP(w, r)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Request completed successfully.
+			return
+		case p := <-panicChan:
+			// Panic occurred in handler.
+			panic(p)
+		case <-ctx.Done():
+			// Context was cancelled (timeout occurred).
+			if app.flightRecorder != nil {
+				go app.flightRecorder.CaptureTimeoutTrace(context.Background(), method, path)
+			}
+
+			// Return timeout error.
+			http.Error(w, "timed out", http.StatusGatewayTimeout)
+		}
 	})
 }
 

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -148,9 +148,11 @@ func (app *application) logAndTraceRequest(next http.Handler) http.Handler {
 		}
 		app.logger.LogAttrs(r.Context(), level, "request completed",
 			slog.Int("status_code", sw.statusCode), slog.Duration("duration", time.Since(start)))
+
 		// If we have a flight recorder, capture a trace if the request timed out.
+		flightRecorderCtx := context.WithoutCancel(ctx)
 		if sw.statusCode == http.StatusServiceUnavailable && app.flightRecorder != nil {
-			go app.flightRecorder.CaptureTimeoutTrace(context.Background(), method, path)
+			go app.flightRecorder.CaptureTimeoutTrace(flightRecorderCtx)
 		}
 	})
 }

--- a/cmd/web/server.go
+++ b/cmd/web/server.go
@@ -58,10 +58,10 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 			shutdownErr = fmt.Errorf("shutdown server: %w", shutdownErr)
 			app.logger.LogAttrs(logCtx, slog.LevelError, "error shutting down server", slog.Any("error", shutdownErr))
 		}
-		
+
 		// Stop flight recorder after server shutdown
 		app.flightRecorder.Stop(logCtx)
-		
+
 		close(shutdownComplete)
 	}()
 
@@ -86,12 +86,4 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 	<-shutdownComplete
 
 	return nil
-}
-
-// startAndWaitForShutdown starts the application and waits for shutdown signals.
-// It coordinates shutdown of both the HTTP server and flight recorder.
-func (app *application) startAndWaitForShutdown(ctx context.Context, addr string, handler http.Handler) error {
-	// The flight recorder shutdown is now integrated into the server shutdown
-	// in configureAndStartServer, so we just need to start the server
-	return app.configureAndStartServer(ctx, addr, handler)
 }

--- a/cmd/web/server.go
+++ b/cmd/web/server.go
@@ -61,7 +61,7 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 		}
 
 		// Stop flight recorder after server shutdown
-		if app.flightRecorder == nil {
+		if app.flightRecorder != nil {
 			app.flightRecorder.Stop(logCtx)
 		}
 

--- a/cmd/web/server.go
+++ b/cmd/web/server.go
@@ -47,6 +47,7 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 
 		// Create a new context for logging since the original might be cancelled
 		logCtx := context.Background()
+		now := time.Now()
 		app.logger.LogAttrs(logCtx, slog.LevelInfo, "shutting down server", slog.String("reason", shutdownReason))
 
 		// We received an interrupt signal or context cancellation, shut down.
@@ -60,7 +61,11 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 		}
 
 		// Stop flight recorder after server shutdown
-		app.flightRecorder.Stop(logCtx)
+		if app.flightRecorder == nil {
+			app.flightRecorder.Stop(logCtx)
+		}
+
+		app.logger.LogAttrs(logCtx, slog.LevelInfo, "server shut down", slog.Duration("duration", time.Since(now)))
 
 		close(shutdownComplete)
 	}()

--- a/cmd/web/server.go
+++ b/cmd/web/server.go
@@ -58,6 +58,10 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 			shutdownErr = fmt.Errorf("shutdown server: %w", shutdownErr)
 			app.logger.LogAttrs(logCtx, slog.LevelError, "error shutting down server", slog.Any("error", shutdownErr))
 		}
+		
+		// Stop flight recorder after server shutdown
+		app.flightRecorder.Stop(logCtx)
+		
 		close(shutdownComplete)
 	}()
 
@@ -82,4 +86,12 @@ func (app *application) configureAndStartServer(ctx context.Context, addr string
 	<-shutdownComplete
 
 	return nil
+}
+
+// startAndWaitForShutdown starts the application and waits for shutdown signals.
+// It coordinates shutdown of both the HTTP server and flight recorder.
+func (app *application) startAndWaitForShutdown(ctx context.Context, addr string, handler http.Handler) error {
+	// The flight recorder shutdown is now integrated into the server shutdown
+	// in configureAndStartServer, so we just need to start the server
+	return app.configureAndStartServer(ctx, addr, handler)
 }

--- a/cmd/web/templates.go
+++ b/cmd/web/templates.go
@@ -68,24 +68,3 @@ func resolveAndVerifyTemplatePath(templatePath string) (string, error) {
 	}
 	return templatePath, nil
 }
-
-// resolveAndCreateTracesDirectory resolves the traces directory path and creates it if needed.
-//
-// If the tracesDirectory is empty, it will create a 'traces' directory in the module root.
-func resolveAndCreateTracesDirectory(tracesDirectory string) (string, error) {
-	var err error
-	if tracesDirectory == "" {
-		var modulePath string
-		if modulePath, err = findModuleDir(); err != nil {
-			return "", fmt.Errorf("find module dir: %w", err)
-		}
-		tracesDirectory = filepath.Join(modulePath, "traces")
-	}
-
-	// Create the directory if it doesn't exist
-	if err = os.MkdirAll(tracesDirectory, 0755); err != nil {
-		return "", fmt.Errorf("create traces directory: %w", err)
-	}
-
-	return tracesDirectory, nil
-}

--- a/cmd/web/templates.go
+++ b/cmd/web/templates.go
@@ -68,3 +68,24 @@ func resolveAndVerifyTemplatePath(templatePath string) (string, error) {
 	}
 	return templatePath, nil
 }
+
+// resolveAndCreateTracesDirectory resolves the traces directory path and creates it if needed.
+//
+// If the tracesDirectory is empty, it will create a 'traces' directory in the module root.
+func resolveAndCreateTracesDirectory(tracesDirectory string) (string, error) {
+	var err error
+	if tracesDirectory == "" {
+		var modulePath string
+		if modulePath, err = findModuleDir(); err != nil {
+			return "", fmt.Errorf("find module dir: %w", err)
+		}
+		tracesDirectory = filepath.Join(modulePath, "traces")
+	}
+
+	// Create the directory if it doesn't exist
+	if err = os.MkdirAll(tracesDirectory, 0755); err != nil {
+		return "", fmt.Errorf("create traces directory: %w", err)
+	}
+
+	return tracesDirectory, nil
+}

--- a/fly.toml
+++ b/fly.toml
@@ -4,6 +4,7 @@ primary_region = "arn"
 
 [env]
 PETRAPP_SQLITE_URL = "/data/petrapp.sqlite3"
+PETRAPP_TRACES_DIRECTORY = "/data/traces"
 LITESTREAM_REPLICA_TYPE = "s3"
 
 [build]

--- a/internal/flightrecorder/service.go
+++ b/internal/flightrecorder/service.go
@@ -1,0 +1,206 @@
+// Package flightrecorder provides trace capture functionality for request timeouts.
+package flightrecorder
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime/trace"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// defaultMinAge is the minimum age of trace events to keep.
+	defaultMinAge = 5 * time.Minute
+
+	// defaultMaxBytes is the maximum size of the trace buffer.
+	defaultMaxBytes = 64 * 1024 * 1024 // 64MB
+
+	// cooldownDuration is the minimum time between trace captures.
+	cooldownDuration = 30 * time.Minute
+
+	// traceDir is the directory where traces are written.
+	traceDir = "traces"
+)
+
+// Service manages flight recording for timeout detection.
+type Service struct {
+	logger         *slog.Logger
+	flightRecorder *trace.FlightRecorder
+	lastCapture    atomic.Int64 // Unix timestamp of last capture
+	mu             sync.RWMutex
+	started        bool
+}
+
+// Config configures the flight recorder service.
+type Config struct {
+	Logger   *slog.Logger
+	MinAge   time.Duration // Minimum age of trace events
+	MaxBytes uint64        // Maximum size of trace buffer
+}
+
+// New creates a new flight recorder service.
+func New(cfg Config) (*Service, error) {
+	if cfg.Logger == nil {
+		return nil, errors.New("logger is required")
+	}
+
+	minAge := cfg.MinAge
+	if minAge == 0 {
+		minAge = defaultMinAge
+	}
+
+	maxBytes := cfg.MaxBytes
+	if maxBytes == 0 {
+		maxBytes = defaultMaxBytes
+	}
+
+	flightRecorderCfg := trace.FlightRecorderConfig{
+		MinAge:   minAge,
+		MaxBytes: maxBytes,
+	}
+
+	flightRecorder := trace.NewFlightRecorder(flightRecorderCfg)
+	if flightRecorder == nil {
+		return nil, errors.New("failed to create flight recorder")
+	}
+
+	return &Service{
+		logger:         cfg.Logger,
+		flightRecorder: flightRecorder,
+		lastCapture:    atomic.Int64{},
+		mu:             sync.RWMutex{},
+		started:        false,
+	}, nil
+}
+
+// Start begins flight recording.
+func (s *Service) Start(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.started {
+		return errors.New("flight recorder already started")
+	}
+
+	// Create traces directory if it doesn't exist
+	if err := os.MkdirAll(traceDir, 0755); err != nil {
+		return fmt.Errorf("create traces directory: %w", err)
+	}
+
+	if err := s.flightRecorder.Start(); err != nil {
+		return fmt.Errorf("start flight recorder: %w", err)
+	}
+
+	s.started = true
+	s.logger.LogAttrs(ctx, slog.LevelInfo, "flight recorder started",
+		slog.String("min_age", defaultMinAge.String()),
+		slog.Uint64("max_bytes", defaultMaxBytes),
+		slog.String("cooldown", cooldownDuration.String()))
+
+	return nil
+}
+
+// Stop ends flight recording.
+func (s *Service) Stop(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.started {
+		return
+	}
+
+	s.flightRecorder.Stop()
+	s.started = false
+	s.logger.LogAttrs(ctx, slog.LevelInfo, "flight recorder stopped")
+}
+
+// CaptureTimeoutTrace captures a trace when a request times out.
+// It respects the cooldown period to avoid overwhelming the filesystem.
+func (s *Service) CaptureTimeoutTrace(ctx context.Context, method, path string) {
+	s.mu.RLock()
+	if !s.started || !s.flightRecorder.Enabled() {
+		s.mu.RUnlock()
+		return
+	}
+	s.mu.RUnlock()
+
+	// Check cooldown period
+	now := time.Now().Unix()
+	lastCapture := s.lastCapture.Load()
+
+	if lastCapture > 0 && time.Unix(now, 0).Sub(time.Unix(lastCapture, 0)) < cooldownDuration {
+		s.logger.LogAttrs(ctx, slog.LevelDebug, "skipping trace capture due to cooldown",
+			slog.String("method", method),
+			slog.String("path", path),
+			slog.Time("last_capture", time.Unix(lastCapture, 0)),
+			slog.Duration("remaining_cooldown", cooldownDuration-time.Unix(now, 0).Sub(time.Unix(lastCapture, 0))))
+		return
+	}
+
+	// Update last capture time atomically
+	if !s.lastCapture.CompareAndSwap(lastCapture, now) {
+		// Another goroutine updated the timestamp, respect that
+		return
+	}
+
+	// Generate filename with timestamp and request info
+	timestamp := time.Unix(now, 0).UTC().Format("20060102-150405")
+	filename := fmt.Sprintf("timeout-%s-%s-%s.trace", timestamp, method, sanitizePath(path))
+	filepath := filepath.Join(traceDir, filename)
+
+	// Create and write the trace file
+	file, err := os.Create(filepath)
+	if err != nil {
+		s.logger.LogAttrs(ctx, slog.LevelError, "failed to create trace file",
+			slog.String("method", method),
+			slog.String("path", path),
+			slog.String("file", filepath),
+			slog.Any("error", err))
+		return
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			s.logger.LogAttrs(ctx, slog.LevelError, "failed to close trace file",
+				slog.String("file", filepath),
+				slog.Any("error", closeErr))
+		}
+	}()
+
+	// Write the flight recorder trace to file
+	bytesWritten, err := s.flightRecorder.WriteTo(file)
+	if err != nil {
+		s.logger.LogAttrs(ctx, slog.LevelError, "failed to write trace",
+			slog.String("method", method),
+			slog.String("path", path),
+			slog.String("file", filepath),
+			slog.Any("error", err))
+		return
+	}
+
+	s.logger.LogAttrs(ctx, slog.LevelWarn, "captured timeout trace",
+		slog.String("method", method),
+		slog.String("path", path),
+		slog.String("file", filepath),
+		slog.Int64("bytes", bytesWritten))
+}
+
+// sanitizePath removes characters that are problematic in filenames.
+func sanitizePath(path string) string {
+	// Replace path separators and other problematic characters
+	result := ""
+	for _, r := range path {
+		switch r {
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|':
+			result += "_"
+		default:
+			result += string(r)
+		}
+	}
+	return result
+}

--- a/internal/flightrecorder/service.go
+++ b/internal/flightrecorder/service.go
@@ -129,11 +129,8 @@ func (s *Service) Stop(ctx context.Context) {
 
 	s.flightRecorder.Stop()
 	s.started = false
-	
-	// Only log if the context is not cancelled to avoid test writer issues
-	if ctx.Err() == nil {
-		s.logger.LogAttrs(ctx, slog.LevelInfo, "flight recorder stopped")
-	}
+
+	s.logger.LogAttrs(ctx, slog.LevelInfo, "flight recorder stopped")
 }
 
 // CaptureTimeoutTrace captures a trace when a request times out.
@@ -168,22 +165,22 @@ func (s *Service) CaptureTimeoutTrace(ctx context.Context, method, path string) 
 	// Generate filename with timestamp and request info
 	timestamp := time.Unix(now, 0).UTC().Format("20060102-150405")
 	filename := fmt.Sprintf("timeout-%s-%s-%s.trace", timestamp, method, sanitizePath(path))
-	filepath := filepath.Join(s.tracesDirectory, filename)
+	fPath := filepath.Join(s.tracesDirectory, filename)
 
 	// Create and write the trace file
-	file, err := os.Create(filepath)
+	file, err := os.Create(fPath)
 	if err != nil {
 		s.logger.LogAttrs(ctx, slog.LevelError, "failed to create trace file",
 			slog.String("method", method),
 			slog.String("path", path),
-			slog.String("file", filepath),
+			slog.String("file", fPath),
 			slog.Any("error", err))
 		return
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
 			s.logger.LogAttrs(ctx, slog.LevelError, "failed to close trace file",
-				slog.String("file", filepath),
+				slog.String("file", fPath),
 				slog.Any("error", closeErr))
 		}
 	}()
@@ -194,7 +191,7 @@ func (s *Service) CaptureTimeoutTrace(ctx context.Context, method, path string) 
 		s.logger.LogAttrs(ctx, slog.LevelError, "failed to write trace",
 			slog.String("method", method),
 			slog.String("path", path),
-			slog.String("file", filepath),
+			slog.String("file", fPath),
 			slog.Any("error", err))
 		return
 	}
@@ -202,7 +199,7 @@ func (s *Service) CaptureTimeoutTrace(ctx context.Context, method, path string) 
 	s.logger.LogAttrs(ctx, slog.LevelWarn, "captured timeout trace",
 		slog.String("method", method),
 		slog.String("path", path),
-		slog.String("file", filepath),
+		slog.String("file", fPath),
 		slog.Int64("bytes", bytesWritten))
 }
 

--- a/internal/flightrecorder/service_test.go
+++ b/internal/flightrecorder/service_test.go
@@ -1,0 +1,167 @@
+package flightrecorder_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/myrjola/petrapp/internal/flightrecorder"
+)
+
+func TestService_StartStop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	service, err := flightrecorder.New(flightrecorder.Config{
+		Logger:   logger,
+		MinAge:   0, // Use default
+		MaxBytes: 0, // Use default
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Test starting
+	if err = service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	// Test stopping
+	service.Stop(ctx)
+}
+
+func TestService_CaptureTimeoutTrace(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	service, err := flightrecorder.New(flightrecorder.Config{
+		Logger:   logger,
+		MinAge:   0, // Use default
+		MaxBytes: 0, // Use default
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if err = service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer service.Stop(ctx)
+
+	// Create the traces directory
+	traceDir := "traces"
+	if err = os.MkdirAll(traceDir, 0755); err != nil {
+		t.Fatalf("failed to create trace directory: %v", err)
+	}
+	defer os.RemoveAll(traceDir)
+
+	// Capture a trace
+	service.CaptureTimeoutTrace(ctx, "GET", "/test/path")
+
+	// Check that a trace file was created
+	entries, err := os.ReadDir(traceDir)
+	if err != nil {
+		t.Fatalf("failed to read trace directory: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Error("expected at least one trace file to be created")
+		return
+	}
+
+	// Verify the filename format
+	filename := entries[0].Name()
+	if !strings.HasPrefix(filename, "timeout-") {
+		t.Errorf("expected filename to start with 'timeout-', got %s", filename)
+	}
+	if !strings.HasSuffix(filename, ".trace") {
+		t.Errorf("expected filename to end with '.trace', got %s", filename)
+	}
+	if !strings.Contains(filename, "GET") {
+		t.Errorf("expected filename to contain method 'GET', got %s", filename)
+	}
+	if !strings.Contains(filename, "_test_path") {
+		t.Errorf("expected filename to contain sanitized path '_test_path', got %s", filename)
+	}
+}
+
+func TestService_CooldownPreventsCapture(t *testing.T) {
+	// This test is simplified since we can't access private fields from external package
+	// We'll test that the service can start and stop without errors
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	service, err := flightrecorder.New(flightrecorder.Config{
+		Logger:   logger,
+		MinAge:   0, // Use default
+		MaxBytes: 0, // Use default
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if err = service.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer service.Stop(ctx)
+
+	// Create trace directory
+	traceDir := "traces"
+	if err = os.MkdirAll(traceDir, 0755); err != nil {
+		t.Fatalf("failed to create trace directory: %v", err)
+	}
+	defer os.RemoveAll(traceDir)
+
+	// Capture first trace
+	service.CaptureTimeoutTrace(ctx, "POST", "/cooldown/test")
+
+	// Immediately try to capture another trace (should be blocked by cooldown)
+	service.CaptureTimeoutTrace(ctx, "POST", "/cooldown/test2")
+
+	// Check that only one trace file was created (due to cooldown)
+	entries, err := os.ReadDir(traceDir)
+	if err != nil {
+		t.Fatalf("failed to read trace directory: %v", err)
+	}
+
+	if len(entries) > 1 {
+		t.Error("expected cooldown to prevent rapid successive captures")
+	}
+}
+
+func TestSanitizePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/test/path", "_test_path"},
+		{"/users/{id}", "_users_{id}"},
+		{"path<with>invalid:chars", "path_with_invalid_chars"},
+		{"normal_path", "normal_path"},
+		{`path\with\backslashes`, "path_with_backslashes"},
+		{"path?query=test", "path_query=test"},
+		{"path*wild", "path_wild"},
+	}
+
+	for _, tt := range tests {
+		result := testSanitizePath(tt.input)
+		if result != tt.expected {
+			t.Errorf("sanitizePath(%q) = %q, expected %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+// testSanitizePath is a copy of the private sanitizePath function for testing.
+func testSanitizePath(path string) string {
+	// Replace path separators and other problematic characters
+	result := ""
+	for _, r := range path {
+		switch r {
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|':
+			result += "_"
+		default:
+			result += string(r)
+		}
+	}
+	return result
+}

--- a/internal/flightrecorder/service_test.go
+++ b/internal/flightrecorder/service_test.go
@@ -11,11 +11,15 @@ import (
 )
 
 func TestService_StartStop(t *testing.T) {
+	// Create temporary trace directory
+	traceDir := t.TempDir()
+
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	service, err := flightrecorder.New(flightrecorder.Config{
-		Logger:   logger,
-		MinAge:   0, // Use default
-		MaxBytes: 0, // Use default
+		Logger:          logger,
+		MinAge:          0, // Use default
+		MaxBytes:        0, // Use default
+		TracesDirectory: traceDir,
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -33,11 +37,15 @@ func TestService_StartStop(t *testing.T) {
 }
 
 func TestService_CaptureTimeoutTrace(t *testing.T) {
+	// Create temporary trace directory
+	traceDir := t.TempDir()
+
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	service, err := flightrecorder.New(flightrecorder.Config{
-		Logger:   logger,
-		MinAge:   0, // Use default
-		MaxBytes: 0, // Use default
+		Logger:          logger,
+		MinAge:          0, // Use default
+		MaxBytes:        0, // Use default
+		TracesDirectory: traceDir,
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -48,13 +56,6 @@ func TestService_CaptureTimeoutTrace(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 	defer service.Stop(ctx)
-
-	// Create the traces directory
-	traceDir := "traces"
-	if err = os.MkdirAll(traceDir, 0755); err != nil {
-		t.Fatalf("failed to create trace directory: %v", err)
-	}
-	defer os.RemoveAll(traceDir)
 
 	// Capture a trace
 	service.CaptureTimeoutTrace(ctx, "GET", "/test/path")
@@ -89,11 +90,16 @@ func TestService_CaptureTimeoutTrace(t *testing.T) {
 func TestService_CooldownPreventsCapture(t *testing.T) {
 	// This test is simplified since we can't access private fields from external package
 	// We'll test that the service can start and stop without errors
+
+	// Create temporary trace directory
+	traceDir := t.TempDir()
+
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	service, err := flightrecorder.New(flightrecorder.Config{
-		Logger:   logger,
-		MinAge:   0, // Use default
-		MaxBytes: 0, // Use default
+		Logger:          logger,
+		MinAge:          0, // Use default
+		MaxBytes:        0, // Use default
+		TracesDirectory: traceDir,
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -104,13 +110,6 @@ func TestService_CooldownPreventsCapture(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 	defer service.Stop(ctx)
-
-	// Create trace directory
-	traceDir := "traces"
-	if err = os.MkdirAll(traceDir, 0755); err != nil {
-		t.Fatalf("failed to create trace directory: %v", err)
-	}
-	defer os.RemoveAll(traceDir)
 
 	// Capture first trace
 	service.CaptureTimeoutTrace(ctx, "POST", "/cooldown/test")

--- a/internal/sqlite/schema.sql
+++ b/internal/sqlite/schema.sql
@@ -88,8 +88,8 @@ CREATE TABLE exercises
 CREATE TABLE workout_sessions
 (
     user_id           INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    workout_date      TEXT NOT NULL CHECK (LENGTH(workout_date) <= 10 AND
-                                           DATE(workout_date, '+0 days') IS workout_date),
+    workout_date      TEXT    NOT NULL CHECK (LENGTH(workout_date) <= 10 AND
+                                              DATE(workout_date, '+0 days') IS workout_date),
     difficulty_rating INTEGER CHECK (difficulty_rating BETWEEN 1 AND 5),
     started_at        TEXT CHECK (started_at IS NULL OR STRFTIME('%Y-%m-%dT%H:%M:%fZ', started_at) = started_at),
     completed_at      TEXT CHECK (completed_at IS NULL OR STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),

--- a/internal/testhelpers/testwriter.go
+++ b/internal/testhelpers/testwriter.go
@@ -11,6 +11,7 @@ import (
 type Writer struct {
 	t        *testing.T
 	testDone chan struct{}
+	testName string
 }
 
 // NewWriter creates a new Writer that writes to t.Log.
@@ -19,6 +20,7 @@ func NewWriter(t *testing.T) io.Writer {
 	w := &Writer{
 		t:        t,
 		testDone: make(chan struct{}),
+		testName: t.Name(),
 	}
 	// Close the writer when the test finishes to prevent data races
 	t.Cleanup(func() {
@@ -32,7 +34,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 	select {
 	// If the test has finished, panic to catch server shutdown issues
 	case <-w.testDone:
-		panic("testwriter: attempted to write after test completion. Did you remember to t.Cleanup(server.Shutdown)?")
+		panic("testwriter: attempted to write after test completion in " + w.testName)
 	default:
 		// Remove trailing newlines to avoid double-spacing in test output.
 		output := strings.TrimSuffix(string(p), "\n")

--- a/ui/templates/pages/exerciseset/exerciseset.gohtml
+++ b/ui/templates/pages/exerciseset/exerciseset.gohtml
@@ -413,7 +413,8 @@
             <div class="warmup-banner">
                 <div class="warmup-message">Complete your warmup first</div>
                 <div class="warmup-description">
-                    Warming up properly prepares your muscles and joints for exercise, reducing injury risk and improving performance.
+                    Warming up properly prepares your muscles and joints for exercise, reducing injury risk and
+                    improving performance.
                 </div>
                 <form method="post"
                       action="/workouts/{{ .Date.Format "2006-01-02" }}/exercises/{{ .ExerciseSet.Exercise.ID }}/warmup/complete">
@@ -431,7 +432,8 @@
             </div>
         {{ end }}
 
-        <div class="sets-container{{ if not .ExerciseSet.WarmupCompletedAt }} disabled{{ end }}" aria-label="Exercise sets"{{ if not .ExerciseSet.WarmupCompletedAt }} aria-disabled="true"{{ end }}>
+        <div class="sets-container{{ if not .ExerciseSet.WarmupCompletedAt }} disabled{{ end }}"
+             aria-label="Exercise sets"{{ if not .ExerciseSet.WarmupCompletedAt }} aria-disabled="true"{{ end }}>
 
             {{ range $index, $setDisplay := .SetsDisplay }}
                 {{ $set := $setDisplay.Set }}

--- a/ui/templates/pages/preferences/preferences.gohtml
+++ b/ui/templates/pages/preferences/preferences.gohtml
@@ -254,7 +254,8 @@
 
         <div class="data-export-section">
             <h2>Export Your Data</h2>
-            <p>Download all your workout data as a SQLite database file for your personal records or data portability.</p>
+            <p>Download all your workout data as a SQLite database file for your personal records or data
+                portability.</p>
             <a href="/preferences/export-data" class="export-button" download>
                 Download My Data
             </a>
@@ -263,7 +264,7 @@
         <div class="danger-zone">
             <h2>Danger Zone</h2>
             <p>Permanently delete your account and all your workout data. This action cannot be undone.</p>
-            <form action="/preferences/delete-user" method="post" 
+            <form action="/preferences/delete-user" method="post"
                   onsubmit="return confirm('Are you sure you want to delete your account? This action cannot be undone and will permanently remove all your workout data.')">
                 <button type="submit" class="delete-button">
                     Delete my data

--- a/ui/templates/pages/privacy/privacy.gohtml
+++ b/ui/templates/pages/privacy/privacy.gohtml
@@ -68,13 +68,22 @@
 
         <h2>Authentication & Privacy</h2>
         <p>
-            Petra uses WebAuthn (Web Authentication) for secure, passwordless authentication. This technology provides several privacy benefits:
+            Petra uses WebAuthn (Web Authentication) for secure, passwordless authentication. This technology provides
+            several privacy benefits:
         </p>
         <ul>
-            <li><strong>No usernames required:</strong> Your identity is tied to your device's biometric authentication or security key, not a username or email address</li>
-            <li><strong>No passwords stored:</strong> We never store or have access to your passwords since authentication is handled directly by your device</li>
-            <li><strong>Phishing resistant:</strong> WebAuthn credentials are tied to our specific domain, making phishing attacks ineffective</li>
-            <li><strong>Private by design:</strong> Your biometric data never leaves your device - only cryptographic signatures are shared</li>
+            <li><strong>No usernames required:</strong> Your identity is tied to your device's biometric authentication
+                or security key, not a username or email address
+            </li>
+            <li><strong>No passwords stored:</strong> We never store or have access to your passwords since
+                authentication is handled directly by your device
+            </li>
+            <li><strong>Phishing resistant:</strong> WebAuthn credentials are tied to our specific domain, making
+                phishing attacks ineffective
+            </li>
+            <li><strong>Private by design:</strong> Your biometric data never leaves your device - only cryptographic
+                signatures are shared
+            </li>
         </ul>
 
         <h2>Data We Store</h2>
@@ -82,13 +91,18 @@
             Petra stores minimal data necessary for the fitness tracking functionality:
         </p>
         <ul>
-            <li><strong>Workout data:</strong> Your exercise sessions, sets, reps, and weights to track your progress</li>
-            <li><strong>Exercise preferences:</strong> Your customized exercise selections and difficulty preferences</li>
-            <li><strong>WebAuthn credentials:</strong> Cryptographic public keys and credential IDs for authentication (no biometric data)</li>
+            <li><strong>Workout data:</strong> Your exercise sessions, sets, reps, and weights to track your progress
+            </li>
+            <li><strong>Exercise preferences:</strong> Your customized exercise selections and difficulty preferences
+            </li>
+            <li><strong>WebAuthn credentials:</strong> Cryptographic public keys and credential IDs for authentication
+                (no biometric data)
+            </li>
             <li><strong>Session data:</strong> Temporary authentication tokens to keep you logged in</li>
         </ul>
         <p>
-            We do not store personal identifiers like names, email addresses, or any biometric data. All data is stored locally on our servers and is not shared with third parties.
+            We do not store personal identifiers like names, email addresses, or any biometric data. All data is stored
+            locally on our servers and is not shared with third parties.
         </p>
 
         <h2>Cookies & Security</h2>
@@ -96,10 +110,13 @@
             Petra uses the following cookies to ensure security and functionality:
         </p>
         <ul>
-            <li><code>session</code> - Secure, HTTP-only session cookie that maintains your authenticated state. Expires when you close your browser or after a period of inactivity.</li>
+            <li><code>session</code> - Secure, HTTP-only session cookie that maintains your authenticated state. Expires
+                when you close your browser or after a period of inactivity.
+            </li>
         </ul>
         <p>
-            Both cookies are set with secure flags (Secure, HttpOnly, SameSite) to prevent unauthorized access and ensure they're only transmitted over encrypted connections.
+            Both cookies are set with secure flags (Secure, HttpOnly, SameSite) to prevent unauthorized access and
+            ensure they're only transmitted over encrypted connections.
         </p>
 
         <h2>Data Security</h2>
@@ -108,15 +125,21 @@
         </p>
         <ul>
             <li><strong>HTTPS encryption:</strong> All data transmission is encrypted using TLS</li>
-            <li><strong>CSRF protection:</strong> Modern browser CSRF protection with SameSite="Lax" cookies and Sec-Fetch-Site header checking.</li>
+            <li><strong>CSRF protection:</strong> Modern browser CSRF protection with SameSite="Lax" cookies and
+                Sec-Fetch-Site header checking.
+            </li>
             <li><strong>Content Security Policy:</strong> Strict CSP headers prevent code injection attacks</li>
             <li><strong>SQL injection prevention:</strong> All database queries use parameterized statements</li>
-            <li><strong>Secure session management:</strong> Sessions use cryptographically secure tokens with appropriate expiration</li>
+            <li><strong>Secure session management:</strong> Sessions use cryptographically secure tokens with
+                appropriate expiration
+            </li>
         </ul>
 
         <h2>Data Retention</h2>
         <p>
-            Your workout data is retained to provide historical tracking and progress analysis. You can request deletion of your data by clearing your browser's stored credentials, which will prevent future access to your account. WebAuthn credentials that are no longer used are automatically cleaned up over time.
+            Your workout data is retained to provide historical tracking and progress analysis. You can request deletion
+            of your data by clearing your browser's stored credentials, which will prevent future access to your
+            account. WebAuthn credentials that are no longer used are automatically cleaned up over time.
         </p>
     </main>
 {{ end }}

--- a/ui/templates/pages/workout/workout.gohtml
+++ b/ui/templates/pages/workout/workout.gohtml
@@ -83,7 +83,7 @@
                     {{ $hasFullBody = true }}
                 {{ end }}
             {{ end }}
-            
+
             {{ $workoutType := "Full Body" }}
             {{ if $hasFullBody }}
                 {{ $workoutType = "Full Body" }}
@@ -94,9 +94,9 @@
             {{ else if $hasLower }}
                 {{ $workoutType = "Lower Body" }}
             {{ end }}
-            
+
             <h1>{{ $workoutType }} Workout - {{ .Date.Format "Monday, January 2, 2006" }}</h1>
-            
+
             <div class="workout-meta">
                 {{ if not .Session.CompletedAt.IsZero }}
                     <span class="status-badge completed">Completed</span>


### PR DESCRIPTION
Implements Go 1.25's flight recorder to capture execution traces when HTTP requests timeout.

## Features
- Automatic trace capture on request timeouts
- 30-minute cooldown between captures to prevent disk space issues
- Configurable trace retention (5 minutes default)
- Thread-safe service with proper lifecycle management
- Sanitized filenames with timestamp and request details

## Integration
- Added FlightRecorder service to application struct
- Modified timeout middleware to detect timeouts and trigger trace capture
- Traces written to `traces/` directory

Closes #28

Generated with [Claude Code](https://claude.ai/code)