### PR TITLE
Add view transition animation for exercise name between pages

### DIFF
--- a/ui/templates/pages/exercise-info/exercise-info.gohtml
+++ b/ui/templates/pages/exercise-info/exercise-info.gohtml
@@ -38,6 +38,7 @@
                         h1 {
                             font-size: var(--font-size-4);
                             font-weight: var(--font-weight-6);
+                            view-transition-name: exercise-title-{{ .Exercise.ID }};
                         }
 
                         .admin-edit {


### PR DESCRIPTION
Add smooth view transition animation for exercise name when navigating from exercise set page to exercise info page.

## Changes
- Add `view-transition-name: exercise-title-{{ .Exercise.ID }}` to exercise info page header
- Matches existing transition name from exercise set page
- Leverages existing CSS View Transitions API configuration

## Result
Creates smooth animation when navigating via Info button, providing better visual continuity and user experience.

Fixes #31

Generated with [Claude Code](https://claude.ai/code)