### PR TITLE
Add user-added exercises feature specification

### DIFF
--- a/specs/user-added-exercises/implementation-plan.md
+++ b/specs/user-added-exercises/implementation-plan.md
@@ -1,0 +1,446 @@
+# User Added Exercises - Implementation Plan
+
+## Overview
+
+This document provides a step-by-step implementation plan for adding user-specific exercises to PetrApp. The implementation follows the shared table approach recommended in the specification.
+
+## Implementation Phases
+
+### Phase 1: Database Schema (Foundation)
+
+**Objective**: Update database schema to support user-owned exercises.
+
+**Tasks**:
+1. Update `schema.sql` to add `user_id` column to exercises table
+   ```sql
+   ALTER TABLE exercises
+   ADD COLUMN user_id INTEGER REFERENCES users (id) ON DELETE CASCADE;
+
+   CREATE INDEX exercises_user_id_idx ON exercises (user_id);
+   ```
+
+2. Update `fixtures.sql` to explicitly set `user_id = NULL` for system exercises
+   - While NULL is default, being explicit in fixtures improves clarity
+   - Helps document the system exercise convention
+
+3. Test schema migration
+   - Run `make test` to ensure migration system accepts changes
+   - Verify that existing exercises remain unaffected (user_id = NULL)
+
+**Files to Modify**:
+- `internal/sqlite/schema.sql`
+- `internal/sqlite/fixtures.sql`
+
+**Testing**:
+- Existing tests should pass (backward compatible change)
+- Database migration should complete successfully
+
+---
+
+### Phase 2: Repository Layer (Data Access)
+
+**Objective**: Update exercise repository to filter by user ownership.
+
+**Tasks**:
+
+1. **Add user context helper** (`internal/workout/repository.go`)
+   - Create helper function to extract user_id from context
+   - Use existing `contexthelpers.AuthenticatedUserID(ctx)` pattern
+   ```go
+   func getUserIDFromContext(ctx context.Context) int {
+       return contexthelpers.AuthenticatedUserID(ctx)
+   }
+   ```
+
+2. **Update `List()` method** (`internal/workout/repository-exercises.go`)
+   - Modify query to return system exercises + user's exercises
+   ```sql
+   SELECT id, name, category, exercise_type, description_markdown
+   FROM exercises
+   WHERE user_id IS NULL OR user_id = ?
+   ORDER BY id
+   ```
+   - Extract user_id from context
+   - Handle unauthenticated context (return only system exercises)
+
+3. **Update `Get()` method** (`internal/workout/repository-exercises.go`)
+   - Add visibility check after fetching exercise
+   - Return `ErrNotFound` if exercise belongs to different user
+   ```go
+   if exercise.UserID != nil && *exercise.UserID != userID {
+       return Exercise{}, ErrNotFound
+   }
+   ```
+
+4. **Update `Create()` method** (`internal/workout/repository-exercises.go`)
+   - Extract user_id from context
+   - Include user_id in INSERT statement
+   ```sql
+   INSERT INTO exercises (name, category, exercise_type, description_markdown, user_id)
+   VALUES (?, ?, ?, ?, ?)
+   ```
+   - Use NULL for system exercises (admin-only feature, future work)
+
+5. **Update `Update()` method** (`internal/workout/repository-exercises.go`)
+   - Add ownership check before allowing update
+   - Return error if user doesn't own exercise
+   ```go
+   if exercise.UserID != nil && *exercise.UserID != userID {
+       return fmt.Errorf("cannot update exercise owned by different user")
+   }
+   ```
+
+**Files to Modify**:
+- `internal/workout/repository-exercises.go`
+
+**Domain Model Update**:
+- Add `UserID *int` field to `Exercise` struct in `internal/workout/models.go`
+- Update JSON schema in `exerciseJSONSchema` if needed
+
+**Testing**:
+- Add unit tests for repository methods with user context
+- Test visibility rules (user can't see other user's exercises)
+- Test ownership rules (user can't edit other user's exercises)
+
+---
+
+### Phase 3: Service Layer (Business Logic)
+
+**Objective**: Update service methods to pass user context to repository.
+
+**Tasks**:
+
+1. **Update `List()` method** (`internal/workout/service.go`)
+   - Service already calls `repo.exercises.List(ctx)`
+   - Should work automatically with updated repository
+   - No changes needed if repository handles context internally
+
+2. **Update `GetExercise()` method** (`internal/workout/service.go`)
+   - Repository already handles visibility
+   - No changes needed
+
+3. **Update `GenerateExercise()` method** (`internal/workout/service.go`)
+   - Ensure created exercise gets user_id from context
+   - Repository Create() should handle this automatically
+   - No explicit changes needed
+
+4. **Update `UpdateExercise()` method** (`internal/workout/service.go`)
+   - Repository Update() already checks ownership
+   - No changes needed
+
+5. **Add exercise ownership validation helpers** (optional)
+   - Consider adding service-level helpers for ownership checks
+   - Could be useful for future admin features
+
+**Files to Modify**:
+- `internal/workout/service.go` (minimal changes, mostly verification)
+
+**Testing**:
+- Service tests should pass with updated repository
+- Add integration tests for end-to-end exercise creation flow
+
+---
+
+### Phase 4: HTTP Handlers (User Interface)
+
+**Objective**: Update web handlers to work with user-specific exercises.
+
+**Tasks**:
+
+1. **Review exercise listing handlers**
+   - Identify all places where exercises are listed/selected
+   - Examples: workout page, exercise swap, add exercise
+   - Verify they use `workoutService.List(ctx)` which now filters correctly
+
+2. **Add visual indicators for user exercises**
+   - Update templates to show badge/icon for user-created exercises
+   - Check `Exercise.UserID` in template to determine if user-created
+   - Example: Show "Custom" badge or user icon next to exercise name
+
+3. **Update exercise info handler** (`cmd/web/handler-exercise-info.go`)
+   - Add "Edit" button only if user owns exercise (UserID matches authenticated user)
+   - Could add `Editable bool` field to template data for clarity
+
+4. **Create exercise creation UI** (if not exists)
+   - May already exist via GenerateExercise flow
+   - Ensure it's accessible to all users (not just admins)
+   - Wire up to existing `GenerateExercise` service method
+
+5. **Add exercise management page** (optional for v1)
+   - List user's custom exercises
+   - Allow editing/deleting
+   - Could be added later
+
+**Files to Modify**:
+- `cmd/web/handler-exerciseset.go` (add editability checks)
+- `cmd/web/handler-exercise-info.go` (add edit controls)
+- Templates in `ui/templates/pages/` (add visual indicators)
+
+**Testing**:
+- End-to-end tests for exercise visibility in UI
+- Test that users can't access edit pages for exercises they don't own
+- Test visual indicators appear correctly
+
+---
+
+### Phase 5: Templates & UI (Frontend)
+
+**Objective**: Update templates to show user exercise ownership and enable editing.
+
+**Tasks**:
+
+1. **Update exercise list templates**
+   - Add visual indicator for user exercises
+   - Example in template:
+   ```html
+   {{if .Exercise.UserID}}
+     <span class="badge">Custom</span>
+   {{end}}
+   ```
+
+2. **Update exercise detail template**
+   - Show "Edit" button only for user-owned exercises
+   - Use scoped CSS for any new styling (per template guidelines)
+
+3. **Update exercise selector templates**
+   - Ensure user exercises appear in selection lists
+   - Maintain visual distinction between system and user exercises
+
+4. **Add accessibility considerations**
+   - Ensure screen readers announce custom exercise status
+   - Use semantic HTML and ARIA labels where appropriate
+
+**Files to Modify**:
+- `ui/templates/pages/exerciseset/` (exercise detail view)
+- `ui/templates/pages/workout/` (exercise selection)
+- Templates for any other exercise listing views
+
+**Testing**:
+- Manual testing of UI with multiple users
+- Verify visual indicators appear correctly
+- Test responsive design
+
+---
+
+### Phase 6: Testing & Validation
+
+**Objective**: Comprehensive testing of user exercise features.
+
+**Tasks**:
+
+1. **Unit Tests**
+   - Repository layer tests for ownership filtering
+   - Service layer tests for user context propagation
+   - Test edge cases: unauthenticated users, NULL user_id
+
+2. **Integration Tests**
+   - End-to-end exercise creation flow
+   - Exercise visibility across different users
+   - Workout usage with user exercises
+
+3. **Security Tests**
+   - Verify users cannot access other users' exercises
+   - Verify users cannot edit other users' exercises
+   - Test URL manipulation attempts
+
+4. **Performance Tests**
+   - Measure query performance with user filtering
+   - Ensure <100ms for exercise list queries
+   - Check for N+1 queries
+
+5. **Manual Testing**
+   - Create exercises as different users
+   - Verify visibility rules
+   - Test workout integration
+   - Test data export includes user exercises
+
+**Testing Checklist**:
+- [ ] Repository tests pass
+- [ ] Service tests pass
+- [ ] Handler tests pass
+- [ ] End-to-end tests pass
+- [ ] Security tests pass
+- [ ] Performance is acceptable
+- [ ] Manual testing complete
+
+---
+
+### Phase 7: Data Export (GDPR Compliance)
+
+**Objective**: Ensure user data export includes custom exercises.
+
+**Tasks**:
+
+1. **Review existing data export** (`internal/workout/service.go:ExportUserData`)
+   - Check if exercises are already included in export
+   - If exercises table is already exported, user exercises will be included automatically
+
+2. **Verify export includes user_id column**
+   - Ensure exported schema includes user_id
+   - User should be able to identify their custom exercises in export
+
+3. **Test export functionality**
+   - Create user with custom exercises
+   - Export data
+   - Verify exercises are included with correct user_id
+
+**Files to Review**:
+- `internal/workout/service.go` (ExportUserData method)
+- `internal/sqlite/database.go` (CreateUserDB method)
+
+---
+
+## Implementation Order
+
+**Recommended sequence** (each phase depends on previous):
+
+1. Phase 1: Database Schema ✓ (foundation)
+2. Phase 2: Repository Layer ✓ (data access)
+3. Phase 3: Service Layer ✓ (business logic)
+4. Phase 4: HTTP Handlers ✓ (API)
+5. Phase 5: Templates & UI ✓ (frontend)
+6. Phase 6: Testing ✓ (validation)
+7. Phase 7: Data Export ✓ (compliance)
+
+Each phase should be completed and tested before moving to the next.
+
+---
+
+## Rollout Strategy
+
+### Development
+1. Implement behind feature flag (optional)
+2. Test with development database
+3. Create sample user exercises for testing
+
+### Staging
+1. Deploy schema changes first
+2. Deploy code changes
+3. Verify migration succeeds
+4. Test with multiple test users
+
+### Production
+1. Deploy schema changes (backward compatible)
+2. Deploy code changes
+3. Monitor error rates and performance
+4. Gather user feedback
+
+---
+
+## Rollback Plan
+
+If issues arise after deployment:
+
+1. **Schema rollback**: Drop user_id column
+   ```sql
+   DROP INDEX exercises_user_id_idx;
+   ALTER TABLE exercises DROP COLUMN user_id;
+   ```
+   - Safe if no users have created exercises yet
+   - Data loss if users have created exercises
+
+2. **Code rollback**: Revert to previous version
+   - Repository queries revert to unfiltered
+   - User exercises become system exercises (visible to all)
+
+3. **Mitigation**: Use feature flag
+   - If implemented with feature flag, can disable feature without rollback
+   - Recommended for production deployment
+
+---
+
+## Monitoring & Metrics
+
+After deployment, monitor:
+
+1. **Query Performance**
+   - Exercise list query time
+   - Watch for slow queries with user_id filtering
+
+2. **Usage Metrics**
+   - Number of custom exercises created
+   - Percentage of users creating exercises
+   - Most common exercise types created
+
+3. **Error Rates**
+   - 404s for exercise not found
+   - Permission errors for exercise access
+   - Database errors
+
+4. **User Feedback**
+   - Support requests related to custom exercises
+   - Bug reports
+   - Feature requests
+
+---
+
+## Future Enhancements
+
+Once v1 is stable, consider:
+
+1. **Exercise Sharing**: Allow users to share exercises with specific users or make public
+2. **Exercise Templates**: Pre-made templates users can customize
+3. **Bulk Import**: Import exercises from CSV or other formats
+4. **Exercise Analytics**: Show which user exercises are most popular
+5. **Exercise Versioning**: Track changes to exercise descriptions over time
+6. **Admin Controls**: Admin panel for managing system exercises
+
+---
+
+## Resources & References
+
+- **Architecture Guidelines**: `/home/runner/work/petrapp/petrapp/CLAUDE.md`
+- **Database Guidelines**: `/home/runner/work/petrapp/petrapp/internal/sqlite/CLAUDE.md`
+- **Domain Guidelines**: `/home/runner/work/petrapp/petrapp/internal/workout/CLAUDE.md`
+- **Web Guidelines**: `/home/runner/work/petrapp/petrapp/cmd/web/CLAUDE.md`
+- **Template Guidelines**: `/home/runner/work/petrapp/petrapp/ui/templates/CLAUDE.md`
+
+---
+
+## Estimated Effort
+
+| Phase | Estimated Time | Complexity |
+|-------|---------------|------------|
+| 1. Database Schema | 1 hour | Low |
+| 2. Repository Layer | 3-4 hours | Medium |
+| 3. Service Layer | 1-2 hours | Low |
+| 4. HTTP Handlers | 2-3 hours | Medium |
+| 5. Templates & UI | 2-3 hours | Medium |
+| 6. Testing | 4-5 hours | Medium |
+| 7. Data Export | 1 hour | Low |
+| **Total** | **14-19 hours** | **Medium** |
+
+**Note**: Estimates assume familiarity with codebase and no major blockers.
+
+---
+
+## Success Criteria
+
+The implementation is complete when:
+
+1. ✓ Schema migration adds user_id column successfully
+2. ✓ Users can create custom exercises
+3. ✓ Custom exercises only visible to creator
+4. ✓ Custom exercises work in workouts (add, swap, track)
+5. ✓ Users can edit their own exercises
+6. ✓ System exercises remain uneditable by regular users
+7. ✓ All tests pass
+8. ✓ Performance meets requirements (<100ms queries)
+9. ✓ Data export includes custom exercises
+10. ✓ No security vulnerabilities (users can't access others' exercises)
+
+---
+
+## Getting Started
+
+To begin implementation:
+
+1. Review this plan and the specification document
+2. Set up development environment with `make init`
+3. Create a feature branch: `git checkout -b feature/user-exercises`
+4. Start with Phase 1 (Database Schema)
+5. Run tests after each phase: `make test`
+6. Commit frequently with descriptive messages
+7. Use `make ci` for comprehensive validation before PR
+
+For questions or clarification, refer to the specification document or consult the team.

--- a/specs/user-added-exercises/spec.md
+++ b/specs/user-added-exercises/spec.md
@@ -1,0 +1,232 @@
+# User Added Exercises - Feature Specification
+
+## Overview
+
+This feature allows users to create their own custom exercises that are private to them and not visible to other users. Users can add these custom exercises to their workouts alongside the system-provided exercises.
+
+## Requirements
+
+### Functional Requirements
+
+1. **Exercise Creation**
+   - Users can create new exercises with the same attributes as system exercises:
+     - Name (required, max 124 characters)
+     - Category (full_body, upper, lower)
+     - Exercise type (weighted, bodyweight)
+     - Description (markdown format, max 20000 characters)
+     - Primary muscle groups (optional, from predefined list)
+     - Secondary muscle groups (optional, from predefined list)
+   - Exercise creation should support both manual entry and AI-assisted generation (existing GenerateExercise flow)
+
+2. **Exercise Visibility**
+   - System exercises (pre-populated in fixtures) are visible to all users
+   - User-created exercises are only visible to their creator
+   - Users cannot see exercises created by other users
+
+3. **Exercise Usage**
+   - User-created exercises can be used in workouts exactly like system exercises
+   - User-created exercises can be swapped, added, removed from workouts
+   - Historical data (weights, reps) for user exercises is tracked per user
+
+4. **Exercise Management**
+   - Users can edit their own exercises
+   - Users can view detailed information about their exercises
+   - System exercises cannot be edited by regular users (admin-only)
+
+### Non-Functional Requirements
+
+1. **Data Integrity**
+   - Foreign key relationships must be maintained
+   - Deleting a user must cascade-delete their custom exercises
+   - Workout sessions must handle both system and user exercises seamlessly
+
+2. **Performance**
+   - Exercise list queries should be efficient (single query preferred)
+   - No N+1 query problems when loading exercises with muscle groups
+
+3. **Security**
+   - Users cannot access or modify exercises they don't own
+   - API endpoints must validate exercise ownership
+   - Data export must include user's custom exercises
+
+## Design Decision: Shared Table vs. Separate Table
+
+After analyzing the codebase, I recommend using a **shared table approach** with a nullable `user_id` column.
+
+### Approach 1: Shared Table (RECOMMENDED)
+
+Add a nullable `user_id` column to the existing `exercises` table:
+
+```sql
+ALTER TABLE exercises ADD COLUMN user_id INTEGER REFERENCES users (id) ON DELETE CASCADE;
+```
+
+**Advantages:**
+1. **Minimal code changes**: Existing queries work with minor WHERE clause additions
+2. **Unified exercise model**: No need for separate domain types or repository methods
+3. **Simpler foreign keys**: `workout_exercise` and `exercise_sets` tables don't need changes
+4. **Better performance**: Single table queries are faster than JOINs or UNIONs
+5. **Easier maintenance**: One table schema, one set of indexes, one migration path
+6. **Natural NULL semantics**: NULL user_id = system exercise, works perfectly with SQL
+
+**Disadvantages:**
+1. **Schema ambiguity**: NULL user_id convention must be documented
+2. **Query complexity**: Most queries need `WHERE user_id IS NULL OR user_id = ?`
+3. **Index overhead**: Additional index on user_id column
+
+**Changes Required:**
+- Schema: Add nullable `user_id` column with foreign key and index
+- Repository: Update List() query to filter by user context
+- Repository: Update Create() to accept user_id parameter
+- Service: Pass user_id from context when creating exercises
+- Tests: Update fixtures to ensure NULL user_id for system exercises
+
+### Approach 2: Separate Table (NOT RECOMMENDED)
+
+Create a new `user_exercises` table with identical structure to `exercises`.
+
+**Advantages:**
+1. **Clear separation**: System vs user exercises are explicitly different tables
+2. **No NULL handling**: User exercises always have user_id
+3. **Independent evolution**: Could add user-specific fields later without affecting system exercises
+
+**Disadvantages:**
+1. **Significant code duplication**: Need separate repository methods, models, or complex abstractions
+2. **Complex foreign keys**: `workout_exercise` and `exercise_sets` would need polymorphic references or separate user_exercise_id columns
+3. **Query complexity**: Need UNION queries to get all exercises for a user
+4. **More migrations**: Two tables to maintain and migrate
+5. **Harder to ensure consistency**: Duplicate schema means double the maintenance burden
+6. **Worse performance**: UNION queries are slower than filtered single-table queries
+
+**Changes Required:**
+- Schema: New user_exercises table with same structure as exercises
+- Schema: Update workout_exercise and exercise_sets with additional FK columns
+- Repository: Separate methods or complex abstraction for user exercises
+- Service: Logic to decide which table to query/update
+- Tests: Duplicate test fixtures and test cases
+
+### Recommendation: Shared Table
+
+The shared table approach is strongly recommended because:
+
+1. **Least intrusive**: Aligns with the requirement to add this feature with minimal disruption
+2. **Leverages existing code**: 90% of current code can be reused with small modifications
+3. **Better performance**: Single indexed query vs. UNION or multiple queries
+4. **Simpler to understand**: The codebase uses nullable foreign keys elsewhere (see `workout_sessions.difficulty_rating`)
+5. **Easier to test**: Existing tests mostly continue to work with minor adjustments
+6. **Future-proof**: If we later need user-specific fields, we can add nullable columns
+
+## Data Model (Shared Table Approach)
+
+### Updated Schema
+
+```sql
+-- Add user_id column to exercises table
+ALTER TABLE exercises
+ADD COLUMN user_id INTEGER REFERENCES users (id) ON DELETE CASCADE;
+
+-- Add index for efficient user exercise queries
+CREATE INDEX exercises_user_id_idx ON exercises (user_id);
+
+-- System exercises have NULL user_id
+-- User exercises have their creator's user_id
+```
+
+### Exercise Ownership Rules
+
+| user_id Value | Meaning | Visible To | Editable By |
+|--------------|---------|------------|-------------|
+| NULL | System exercise | All users | Admins only |
+| <user_id> | User exercise | That user only | That user only |
+
+### Query Patterns
+
+```sql
+-- Get all exercises for a user (system + their own)
+SELECT * FROM exercises
+WHERE user_id IS NULL OR user_id = ?
+ORDER BY id;
+
+-- Get only system exercises
+SELECT * FROM exercises
+WHERE user_id IS NULL
+ORDER BY id;
+
+-- Get only a user's exercises
+SELECT * FROM exercises
+WHERE user_id = ?
+ORDER BY id;
+
+-- Check if user owns an exercise
+SELECT COUNT(*) FROM exercises
+WHERE id = ? AND user_id = ?;
+```
+
+## User Interface
+
+### Exercise List View
+- Show system exercises and user exercises together
+- Visually distinguish user exercises (e.g., badge or icon)
+- Add "Create Exercise" button/link
+
+### Exercise Creation Flow
+1. User enters exercise name
+2. System attempts AI generation (if OpenAI API key configured)
+3. User reviews and edits generated exercise details
+4. User saves exercise (stored with their user_id)
+
+### Exercise Detail View
+- Show "Edit" button only for exercises user owns
+- For system exercises, show read-only view
+
+### Workout Exercise Selector
+- List shows system exercises + user's own exercises
+- User exercises marked with visual indicator
+- Filtering/search works across both types
+
+## Security Considerations
+
+1. **Authorization**: All exercise CRUD operations must verify ownership
+2. **Data Isolation**: User queries must filter by user_id to prevent data leaks
+3. **GDPR Compliance**: User data export must include their custom exercises
+4. **Context Validation**: Always extract user_id from authenticated context, never from request parameters
+
+## Migration Strategy
+
+1. **Schema Migration**: Add nullable user_id column to exercises table
+2. **Data Migration**: Existing exercises get NULL user_id (system exercises)
+3. **Code Migration**: Update repository layer first (backward compatible)
+4. **Service Migration**: Update service layer to pass user context
+5. **Handler Migration**: Update handlers to use new service methods
+6. **Testing**: Add tests for user exercise visibility and ownership
+
+## Open Questions
+
+1. **Exercise Deletion**: Should users be able to delete their exercises if used in historical workouts?
+   - **Recommendation**: Use CASCADE DELETE - deleting exercise removes it from all workouts (workout history preserved but exercise details lost)
+   - **Alternative**: Soft delete with `deleted_at` timestamp to preserve history
+
+2. **Exercise Limits**: Should there be a limit on how many exercises a user can create?
+   - **Recommendation**: Start without limits, add if abuse occurs
+
+3. **Exercise Sharing**: Should users be able to share exercises with other users?
+   - **Recommendation**: Not in v1, could be added later with additional visibility flags
+
+4. **Import/Export**: Should users be able to export/import exercise definitions?
+   - **Recommendation**: Include in user data export for GDPR compliance, import can be added later
+
+## Success Metrics
+
+1. **Adoption**: Percentage of users who create at least one custom exercise
+2. **Usage**: Number of custom exercises created per user
+3. **Retention**: Whether custom exercise users have higher retention
+4. **Performance**: Query performance remains within acceptable bounds (<100ms for exercise lists)
+
+## Out of Scope for v1
+
+- Exercise sharing between users
+- Exercise templates or marketplace
+- Bulk exercise import/export
+- Exercise versioning or history
+- Advanced muscle group visualization
+- Exercise categorization beyond existing category field


### PR DESCRIPTION
Research and design for allowing users to create their own custom exercises that are private and not visible to other users.

## Key Decisions

- Use shared table approach (add nullable user_id to exercises table)
- NULL user_id = system exercise, non-null = user exercise
- Minimal code changes with better performance vs separate table
- 7-phase implementation plan with estimated 14-19 hours effort

## Documents

- `specs/user-added-exercises/spec.md`: Feature requirements, design rationale, data model, and security considerations
- `specs/user-added-exercises/implementation-plan.md`: Step-by-step implementation guide across database, repository, service, handler, and UI layers

Resolves #39

Generated with [Claude Code](https://claude.ai/code)