### PR TITLE
Fix floating point rounding error in weight display

### DIFF
--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"strconv"
 
 	"github.com/myrjola/petrapp/internal/contexthelpers"
 )
@@ -26,6 +27,11 @@ func (app *application) pageTemplate(pageName string) (*template.Template, error
 		},
 		"mdToHTML": func() string {
 			panic("not implemented")
+		},
+		"formatFloat": func(f float64) string {
+			// Format float to remove trailing zeros and unnecessary precision.
+			// This handles the floating point rounding errors like 60.900000000000006.
+			return strconv.FormatFloat(f, 'f', -1, 64)
 		},
 	}).ParseFS(app.templateFS, "base.gohtml", fmt.Sprintf("pages/%s/*.gohtml", pageName)); err != nil {
 		return nil, fmt.Errorf("new template: %w", err)
@@ -51,6 +57,11 @@ func (app *application) renderToBuf(ctx context.Context, file string, data any) 
 		},
 		"mdToHTML": func(markdown string) template.HTML {
 			return app.renderMarkdownToHTML(ctx, markdown)
+		},
+		"formatFloat": func(f float64) string {
+			// Format float to remove trailing zeros and unnecessary precision.
+			// This handles the floating point rounding errors like 60.900000000000006.
+			return strconv.FormatFloat(f, 'f', -1, 64)
 		},
 	})
 	if err = t.ExecuteTemplate(buf, "base", data); err != nil {

--- a/ui/templates/pages/exerciseset/exerciseset.gohtml
+++ b/ui/templates/pages/exerciseset/exerciseset.gohtml
@@ -443,7 +443,7 @@
                     <div class="set-info">
                         {{ if eq $.ExerciseSet.Exercise.ExerciseType "weighted" }}
                             <span class="weight"
-                                  aria-label="Weight">{{ if $set.WeightKg }}{{ $set.WeightKg }}{{ else }}0{{ end }} kg</span>
+                                  aria-label="Weight">{{ if $set.WeightKg }}{{ formatFloat $set.WeightKg }}{{ else }}0{{ end }} kg</span>
                         {{ end }}
                         {{ if $set.CompletedReps }}
                             <span class="reps" aria-label="Completed reps">{{ $set.CompletedReps }} reps</span>
@@ -469,7 +469,7 @@
                                                 inputmode="decimal"
                                                 pattern="[0-9,\.]*"
                                                 name="weight"
-                                                value="{{ if $set.WeightKg }}{{ $set.WeightKg }}{{ else }}0{{ end }}"
+                                                value="{{ if $set.WeightKg }}{{ formatFloat $set.WeightKg }}{{ else }}0{{ end }}"
                                                 step="0.5"
                                                 required
                                                 aria-describedby="weight-help-{{ $index }}"


### PR DESCRIPTION
Added formatFloat template function to properly format weight values, removing floating point precision errors like 60.900000000000006.

Fixes #41

Generated with [Claude Code](https://claude.ai/code)