### PR TITLE
Hide timer after 30 minutes on exercise set page

### DIFF
--- a/ui/templates/pages/exerciseset/exerciseset.gohtml
+++ b/ui/templates/pages/exerciseset/exerciseset.gohtml
@@ -367,6 +367,12 @@
               const minutes = Math.floor(seconds / 60);
               const hours = Math.floor(minutes / 60);
 
+              // Hide timer after 30 minutes
+              if (minutes >= 30) {
+                timerDisplay.style.display = 'none';
+                return;
+              }
+
               const displaySeconds = seconds % 60;
               const displayMinutes = minutes % 60;
 


### PR DESCRIPTION
The timer now automatically hides after showing for 30 minutes to reduce visual clutter during longer workout sessions.

Resolves #43

Generated with [Claude Code](https://claude.ai/code)