### PR TITLE
Implement assisted exercises with negative weight support

### DIFF
--- a/cmd/web/handler-exercise-info.go
+++ b/cmd/web/handler-exercise-info.go
@@ -122,7 +122,8 @@ func processEntryData(entry workout.ExerciseProgressEntry, typ workout.ExerciseT
 			if set.WeightKg != nil {
 				weight := *set.WeightKg
 				// For assisted exercises, less negative (closer to 0) is more progress.
-				if weight > progress {
+				// Use first set as sentinel to handle all-negative weight sessions.
+				if len(setDescriptions) == 0 || weight > progress {
 					progress = weight
 				}
 				setDescriptions = append(setDescriptions, fmt.Sprintf("%dx%.1fkg", reps, weight))

--- a/cmd/web/handler-exercise-info.go
+++ b/cmd/web/handler-exercise-info.go
@@ -118,6 +118,15 @@ func processEntryData(entry workout.ExerciseProgressEntry, typ workout.ExerciseT
 				}
 				setDescriptions = append(setDescriptions, fmt.Sprintf("%dx%.1fkg", reps, weight))
 			}
+		case workout.ExerciseTypeAssisted:
+			if set.WeightKg != nil {
+				weight := *set.WeightKg
+				// For assisted exercises, less negative (closer to 0) is more progress.
+				if weight > progress {
+					progress = weight
+				}
+				setDescriptions = append(setDescriptions, fmt.Sprintf("%dx%.1fkg", reps, weight))
+			}
 		case workout.ExerciseTypeBodyweight:
 			if float64(reps) > progress {
 				progress = float64(reps)

--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -171,7 +171,8 @@ func (app *application) findExerciseInSession(session *workout.Session, exercise
 // parseWeightAndReps extracts weight and reps from form data based on exercise type.
 func (app *application) parseWeightAndReps(r *http.Request, exercise workout.Exercise) (float64, int, error) {
 	var weight float64
-	if exercise.ExerciseType == workout.ExerciseTypeWeighted {
+	if exercise.ExerciseType == workout.ExerciseTypeWeighted ||
+		exercise.ExerciseType == workout.ExerciseTypeAssisted {
 		weightStr := r.PostForm.Get("weight")
 		if weightStr == "" {
 			return 0, 0, errors.New("weight not provided for weighted exercise")
@@ -234,8 +235,9 @@ func (app *application) exerciseSetUpdatePOST(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Update weight only for weighted exercises
-	if exercise.ExerciseType == workout.ExerciseTypeWeighted {
+	// Update weight for weighted and assisted exercises.
+	if exercise.ExerciseType == workout.ExerciseTypeWeighted ||
+		exercise.ExerciseType == workout.ExerciseTypeAssisted {
 		if err = app.workoutService.UpdateSetWeight(r.Context(), date, exerciseID, setIndex, weight); err != nil {
 			app.serverError(w, r, fmt.Errorf("update weight: %w", err))
 			return

--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -175,7 +175,7 @@ func (app *application) parseWeightAndReps(r *http.Request, exercise workout.Exe
 		exercise.ExerciseType == workout.ExerciseTypeAssisted {
 		weightStr := r.PostForm.Get("weight")
 		if weightStr == "" {
-			return 0, 0, errors.New("weight not provided for weighted exercise")
+			return 0, 0, errors.New("weight not provided for weighted or assisted exercise")
 		}
 		// Replace comma with dot for decimal numbers.
 		weightStr = strings.Replace(weightStr, ",", ".", 1)

--- a/cmd/web/handler-exerciseset_test.go
+++ b/cmd/web/handler-exerciseset_test.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/myrjola/petrapp/internal/e2etest"
 	"github.com/myrjola/petrapp/internal/testhelpers"
+	"github.com/myrjola/petrapp/internal/workout"
 )
 
 func Test_application_exerciseSet(t *testing.T) {
@@ -346,5 +350,92 @@ func Test_application_exerciseSet_nonexistent_exercise_returns_custom_404(t *tes
 	backButtons := doc.Find("button:contains('Go Back')")
 	if backButtons.Length() == 0 {
 		t.Error("Expected custom 404 page to contain 'Go Back' button")
+	}
+}
+
+func Test_parseWeightAndReps(t *testing.T) {
+	app := &application{} //nolint:exhaustruct // only parseWeightAndReps is under test
+
+	tests := []struct {
+		name       string
+		exercise   workout.Exercise
+		formWeight string
+		formReps   string
+		wantWeight float64
+		wantReps   int
+		wantErr    bool
+	}{
+		{
+			name: "weighted exercise with positive weight",
+			exercise: workout.Exercise{ //nolint:exhaustruct // only ExerciseType matters here
+				ExerciseType: workout.ExerciseTypeWeighted,
+			},
+			formWeight: "20.5",
+			formReps:   "8",
+			wantWeight: 20.5,
+			wantReps:   8,
+			wantErr:    false,
+		},
+		{
+			name: "assisted exercise with negative weight",
+			exercise: workout.Exercise{ //nolint:exhaustruct // only ExerciseType matters here
+				ExerciseType: workout.ExerciseTypeAssisted,
+			},
+			formWeight: "-20",
+			formReps:   "8",
+			wantWeight: -20.0,
+			wantReps:   8,
+			wantErr:    false,
+		},
+		{
+			name: "assisted exercise with comma decimal separator",
+			exercise: workout.Exercise{ //nolint:exhaustruct // only ExerciseType matters here
+				ExerciseType: workout.ExerciseTypeAssisted,
+			},
+			formWeight: "-17,5",
+			formReps:   "10",
+			wantWeight: -17.5,
+			wantReps:   10,
+			wantErr:    false,
+		},
+		{
+			name: "bodyweight exercise ignores weight",
+			exercise: workout.Exercise{ //nolint:exhaustruct // only ExerciseType matters here
+				ExerciseType: workout.ExerciseTypeBodyweight,
+			},
+			formWeight: "",
+			formReps:   "12",
+			wantWeight: 0.0,
+			wantReps:   12,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formValues := url.Values{}
+			if tt.formWeight != "" {
+				formValues.Set("weight", tt.formWeight)
+			}
+			formValues.Set("reps", tt.formReps)
+
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(formValues.Encode()))
+			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("Failed to parse form: %v", err)
+			}
+
+			gotWeight, gotReps, err := app.parseWeightAndReps(r, tt.exercise)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseWeightAndReps() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotWeight != tt.wantWeight {
+				t.Errorf("parseWeightAndReps() weight = %v, want %v", gotWeight, tt.wantWeight)
+			}
+			if gotReps != tt.wantReps {
+				t.Errorf("parseWeightAndReps() reps = %v, want %v", gotReps, tt.wantReps)
+			}
+		})
 	}
 }

--- a/internal/sqlite/fixtures.sql
+++ b/internal/sqlite/fixtures.sql
@@ -340,6 +340,24 @@ VALUES (1, 'Deadlift', 'full_body', 'weighted', '## Instructions
 ## Resources
 - [Video tutorial](https://www.youtube.com/watch?v=ASdvN_XEl_c)
 - [Form guide](https://www.verywellfit.com/how-to-do-a-plank-3120068)
+'),
+       (22, 'Assisted Pull-Up', 'upper', 'assisted',
+        'Use a band or machine for assistance. Enter a **negative** weight to indicate the amount of assistance (e.g. `-20` for 20 kg of assistance). Aim to reduce assistance over time.
+
+## Instructions
+1. Set up the assisted pull-up machine or attach a resistance band to the pull-up bar.
+2. Grip the bar with hands slightly wider than shoulder-width, palms facing away.
+3. Pull yourself up until your chin clears the bar, keeping your core engaged.
+4. Lower yourself slowly under control back to the starting position.
+
+## Common Mistakes
+- Using too much assistance: Gradually reduce the assistance weight as you get stronger.
+- Not going through full range of motion: Ensure full arm extension at the bottom.
+- Swinging: Keep the movement controlled to isolate the back muscles.
+
+## Resources
+- [Video tutorial](https://www.youtube.com/watch?v=H4bE8POkGCg)
+- [Form guide](https://www.verywellfit.com/how-to-do-an-assisted-pull-up-4589052)
 ') ON CONFLICT(id) DO
 UPDATE SET name = excluded.name,
     category = excluded.category,
@@ -420,7 +438,12 @@ VALUES (1, 'Forearms', 0),
        (21, 'Abs', 1),
        (21, 'Obliques', 0),
        (21, 'Shoulders', 0),
-       (21, 'Glutes', 0) ON CONFLICT(exercise_id, muscle_group_name) DO
+       (21, 'Glutes', 0),
+-- Assisted exercises
+       (22, 'Lats', 1),
+       (22, 'Biceps', 1),
+       (22, 'Upper Back', 0),
+       (22, 'Forearms', 0) ON CONFLICT(exercise_id, muscle_group_name) DO
 UPDATE SET is_primary = excluded.is_primary;
 
 INSERT INTO feature_flags (name, enabled)

--- a/internal/sqlite/schema.sql
+++ b/internal/sqlite/schema.sql
@@ -81,7 +81,7 @@ CREATE TABLE exercises
     id                   INTEGER PRIMARY KEY,
     name                 TEXT NOT NULL UNIQUE CHECK (LENGTH(name) < 124),
     category             TEXT NOT NULL CHECK (category IN ('full_body', 'upper', 'lower')),
-    exercise_type        TEXT NOT NULL DEFAULT 'weighted' CHECK (exercise_type IN ('weighted', 'bodyweight')),
+    exercise_type        TEXT NOT NULL DEFAULT 'weighted' CHECK (exercise_type IN ('weighted', 'bodyweight', 'assisted')),
     description_markdown TEXT NOT NULL DEFAULT '' CHECK (LENGTH(description_markdown) < 20000)
 ) STRICT;
 
@@ -116,7 +116,7 @@ CREATE TABLE exercise_sets
     workout_date    TEXT    NOT NULL CHECK (STRFTIME('%Y-%m-%d', workout_date) = workout_date),
     exercise_id     INTEGER NOT NULL,
     set_number      INTEGER NOT NULL CHECK (set_number > 0),
-    weight_kg       REAL CHECK (weight_kg IS NULL OR weight_kg >= 0),
+    weight_kg       REAL,
     min_reps        INTEGER NOT NULL CHECK (min_reps > 0),
     max_reps        INTEGER NOT NULL CHECK (max_reps >= min_reps),
     completed_reps  INTEGER,

--- a/internal/workout/generator.go
+++ b/internal/workout/generator.go
@@ -493,19 +493,29 @@ func (g *generator) createProgressiveSets(
 	return sets
 }
 
-// createDefaultSets creates a default set of exercises for beginners with 8 reps.
-func createDefaultSets(exerciseType ExerciseType) []Set {
-	var weight *float64
-	if exerciseType == ExerciseTypeWeighted {
-		weight = &[]float64{0}[0] // Starting weight of 0 for weighted exercises
-	}
-	// For bodyweight exercises, weight remains nil
-
+// defaultSetsWithWeight creates 3 default sets with the given weight pointer.
+func defaultSetsWithWeight(weight *float64) []Set {
 	return []Set{
 		{WeightKg: weight, MinReps: DefaultReps, MaxReps: DefaultReps, CompletedReps: nil, CompletedAt: nil},
 		{WeightKg: weight, MinReps: DefaultReps, MaxReps: DefaultReps, CompletedReps: nil, CompletedAt: nil},
 		{WeightKg: weight, MinReps: DefaultReps, MaxReps: DefaultReps, CompletedReps: nil, CompletedAt: nil},
 	}
+}
+
+// createDefaultSets creates a default set of exercises for beginners with 8 reps.
+func createDefaultSets(exerciseType ExerciseType) []Set {
+	switch exerciseType {
+	case ExerciseTypeWeighted:
+		weight := 0.0
+		return defaultSetsWithWeight(&weight)
+	case ExerciseTypeAssisted:
+		weight := 0.0 // Start at 0 kg; user adjusts assistance as needed.
+		return defaultSetsWithWeight(&weight)
+	case ExerciseTypeBodyweight:
+		// Bodyweight exercises: weight remains nil.
+		return defaultSetsWithWeight(nil)
+	}
+	return defaultSetsWithWeight(nil)
 }
 
 // findMostRecentExerciseSet finds the most recent performance of a specific exercise.
@@ -579,7 +589,7 @@ func (g *generator) progressSetsLinear(lastExerciseSet exerciseSetAggregate, exe
 		if exerciseType == ExerciseTypeBodyweight {
 			return g.reduceBodyweightDifficulty(lastExerciseSet.Sets)
 		}
-		return reduceWeight(lastExerciseSet.Sets, WeightReductionFactor)
+		return reduceWeight(lastExerciseSet.Sets, WeightReductionFactor, exerciseType)
 	case "completed_max":
 		// If all sets completed at max, increase difficulty
 		if exerciseType == ExerciseTypeBodyweight {
@@ -856,7 +866,7 @@ func (g *generator) reduceDifficulty(sets []Set, exerciseType ExerciseType) []Se
 	if len(sets) > MaxStandardSets {
 		return sets[:len(sets)-1] // Reduce volume
 	}
-	return reduceWeight(sets, WeightReductionFactor) // Reduce intensity
+	return reduceWeight(sets, WeightReductionFactor, exerciseType) // Reduce intensity
 }
 
 // getMostRecentFeedback gets the most recent feedback for a session containing the specified exercise.
@@ -906,13 +916,21 @@ func copySetWithoutCompletion(sets []Set) []Set {
 	})
 }
 
-// reduceWeight reduces the weight by a percentage.
-func reduceWeight(sets []Set, percentage float64) []Set {
+// reduceWeight reduces the weight by a percentage. For assisted exercises, it goes further
+// negative (more assistance) on failure, using StandardWeightIncrementKg as the minimum
+// reduction so a 0 kg start can go negative.
+func reduceWeight(sets []Set, percentage float64, exerciseType ExerciseType) []Set {
 	return transformSets(sets, func(set Set) Set {
 		var newWeight *float64
 		if set.WeightKg != nil {
-			reduction := *set.WeightKg * percentage
-			weightValue := math.Max(0, *set.WeightKg-reduction)
+			var weightValue float64
+			if exerciseType == ExerciseTypeAssisted {
+				reduction := math.Max(StandardWeightIncrementKg, math.Abs(*set.WeightKg)*percentage)
+				weightValue = *set.WeightKg - reduction
+			} else {
+				reduction := *set.WeightKg * percentage
+				weightValue = math.Max(0, *set.WeightKg-reduction)
+			}
 			newWeight = &weightValue
 		}
 		return Set{

--- a/internal/workout/generator.go
+++ b/internal/workout/generator.go
@@ -505,11 +505,8 @@ func defaultSetsWithWeight(weight *float64) []Set {
 // createDefaultSets creates a default set of exercises for beginners with 8 reps.
 func createDefaultSets(exerciseType ExerciseType) []Set {
 	switch exerciseType {
-	case ExerciseTypeWeighted:
+	case ExerciseTypeWeighted, ExerciseTypeAssisted:
 		weight := 0.0
-		return defaultSetsWithWeight(&weight)
-	case ExerciseTypeAssisted:
-		weight := 0.0 // Start at 0 kg; user adjusts assistance as needed.
 		return defaultSetsWithWeight(&weight)
 	case ExerciseTypeBodyweight:
 		// Bodyweight exercises: weight remains nil.

--- a/internal/workout/generator_internal_test.go
+++ b/internal/workout/generator_internal_test.go
@@ -1,6 +1,7 @@
 package workout
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -144,12 +145,6 @@ func verifyGeneratedWorkout(t *testing.T, session sessionAggregate, date time.Ti
 
 		// Verify set parameters
 		for j, set := range exerciseSet.Sets {
-			// Verify all weights are reasonable (skip for bodyweight exercises where weight is nil)
-			if set.WeightKg != nil && *set.WeightKg < 0 {
-				t.Errorf("Exercise %d, set #%d has negative weight: %f",
-					exerciseSet.ExerciseID, j+1, *set.WeightKg)
-			}
-
 			// Verify rep ranges (3-16)
 			if set.MinReps < 3 || set.MaxReps > 16 {
 				t.Errorf("Exercise %d, set #%d has unusual rep range: %d-%d",
@@ -979,4 +974,212 @@ func getAverageWeight(t *testing.T, exerciseSet exerciseSetAggregate) float64 {
 	}
 
 	return total / float64(len(exerciseSet.Sets))
+}
+
+// TestAssistedExerciseDefaultSets verifies that assisted exercises start at 0 kg.
+func TestAssistedExerciseDefaultSets(t *testing.T) {
+	sets := createDefaultSets(ExerciseTypeAssisted)
+
+	if len(sets) != 3 {
+		t.Fatalf("Expected 3 default sets, got %d", len(sets))
+	}
+
+	for i, set := range sets {
+		if set.WeightKg == nil {
+			t.Errorf("Set %d: expected non-nil WeightKg for assisted exercise", i)
+			continue
+		}
+		if *set.WeightKg != 0.0 {
+			t.Errorf("Set %d: expected WeightKg=0.0, got %f", i, *set.WeightKg)
+		}
+		if set.MinReps != DefaultReps || set.MaxReps != DefaultReps {
+			t.Errorf("Set %d: expected %d reps, got %d-%d", i, DefaultReps, set.MinReps, set.MaxReps)
+		}
+	}
+}
+
+// TestReduceWeightForNegativeWeights verifies that reduceWeight moves assisted exercises further
+// negative on failure, including the zero-boundary case.
+func TestReduceWeightForNegativeWeights(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputWeight  float64
+		exerciseType ExerciseType
+		wantWeight   float64
+	}{
+		{
+			name:         "assisted at -20 kg goes more negative",
+			inputWeight:  -20.0,
+			exerciseType: ExerciseTypeAssisted,
+			wantWeight:   -20.0 - math.Max(StandardWeightIncrementKg, 20.0*WeightReductionFactor),
+		},
+		{
+			name:         "assisted at 0 kg zero-boundary uses minimum increment",
+			inputWeight:  0.0,
+			exerciseType: ExerciseTypeAssisted,
+			wantWeight:   -StandardWeightIncrementKg,
+		},
+		{
+			name:         "weighted at 100 kg reduces toward zero",
+			inputWeight:  100.0,
+			exerciseType: ExerciseTypeWeighted,
+			wantWeight:   math.Max(0, 100.0-100.0*WeightReductionFactor),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			weight := tt.inputWeight
+			sets := []Set{
+				{WeightKg: &weight, MinReps: 8, MaxReps: 12, CompletedReps: nil, CompletedAt: nil},
+			}
+
+			result := reduceWeight(sets, WeightReductionFactor, tt.exerciseType)
+
+			if len(result) != 1 {
+				t.Fatalf("Expected 1 set, got %d", len(result))
+			}
+			if result[0].WeightKg == nil {
+				t.Fatal("Expected non-nil WeightKg")
+			}
+			if *result[0].WeightKg != tt.wantWeight {
+				t.Errorf("Expected weight %f, got %f", tt.wantWeight, *result[0].WeightKg)
+			}
+		})
+	}
+}
+
+// TestAssistedExerciseProgression verifies full progression for assisted exercises:
+// starting at 0 kg increases to positive weight, and starting at -20 kg progresses
+// toward 0 and eventually positive weight.
+func TestAssistedExerciseProgression(t *testing.T) {
+	preferences := Preferences{
+		MondayMinutes:    60,
+		TuesdayMinutes:   0,
+		WednesdayMinutes: 60,
+		ThursdayMinutes:  0,
+		FridayMinutes:    60,
+		SaturdayMinutes:  0,
+		SundayMinutes:    0,
+	}
+
+	assistedExercise := Exercise{
+		ID:                    100,
+		Name:                  "Assisted Pull-Up",
+		Category:              CategoryUpper,
+		ExerciseType:          ExerciseTypeAssisted,
+		PrimaryMuscleGroups:   []string{"Lats", "Biceps"},
+		SecondaryMuscleGroups: []string{"Upper Back"},
+		DescriptionMarkdown:   "",
+	}
+
+	// Also need enough exercises for the generator to work.
+	pool := append(createExercisePool(), assistedExercise)
+
+	// Use recent dates so the generator uses linear progression (beginner path), which
+	// directly calls increaseWeight and is the expected behavior for assisted exercises.
+	recentBase := time.Now().AddDate(0, 0, -7)
+	nextWorkoutDate := time.Now().AddDate(0, 0, -5)
+
+	// Scenario 1: starting at 0 kg should increase to positive weight after successful sets.
+	t.Run("progression from 0 kg", func(t *testing.T) {
+		startWeight := 0.0
+		completedReps := 8
+		history := []sessionAggregate{
+			{
+				Date:             recentBase,
+				DifficultyRating: nil,
+				StartedAt:        recentBase.Add(17 * time.Hour),
+				CompletedAt:      recentBase.Add(18 * time.Hour),
+				ExerciseSets: []exerciseSetAggregate{
+					{
+						ExerciseID:        assistedExercise.ID,
+						WarmupCompletedAt: nil,
+						Sets: []Set{
+							{WeightKg: &startWeight, MinReps: 8, MaxReps: 8, CompletedReps: &completedReps, CompletedAt: nil},
+							{WeightKg: &startWeight, MinReps: 8, MaxReps: 8, CompletedReps: &completedReps, CompletedAt: nil},
+							{WeightKg: &startWeight, MinReps: 8, MaxReps: 8, CompletedReps: &completedReps, CompletedAt: nil},
+						},
+					},
+				},
+			},
+		}
+
+		gen, err := newGenerator(preferences, history, pool)
+		if err != nil {
+			t.Fatalf("Failed to create generator: %v", err)
+		}
+
+		nextSession, err := gen.Generate(nextWorkoutDate)
+		if err != nil {
+			t.Fatalf("Failed to generate session: %v", err)
+		}
+
+		for _, es := range nextSession.ExerciseSets {
+			if es.ExerciseID != assistedExercise.ID {
+				continue
+			}
+			for i, set := range es.Sets {
+				if set.WeightKg == nil {
+					t.Errorf("Set %d: expected non-nil WeightKg", i)
+					continue
+				}
+				if *set.WeightKg <= startWeight {
+					t.Errorf("Set %d: expected weight > %f after successful completion, got %f",
+						i, startWeight, *set.WeightKg)
+				}
+			}
+		}
+	})
+
+	// Scenario 2: starting at -20 kg progresses toward 0 after successful completion.
+	t.Run("progression from -20 kg toward 0", func(t *testing.T) {
+		negWeight := -20.0
+		completedReps := 8
+		history := []sessionAggregate{
+			{
+				Date:             recentBase,
+				DifficultyRating: nil,
+				StartedAt:        recentBase.Add(17 * time.Hour),
+				CompletedAt:      recentBase.Add(18 * time.Hour),
+				ExerciseSets: []exerciseSetAggregate{
+					{
+						ExerciseID:        assistedExercise.ID,
+						WarmupCompletedAt: nil,
+						Sets: []Set{
+							{WeightKg: &negWeight, MinReps: 8, MaxReps: 8, CompletedReps: &completedReps, CompletedAt: nil},
+							{WeightKg: &negWeight, MinReps: 8, MaxReps: 8, CompletedReps: &completedReps, CompletedAt: nil},
+							{WeightKg: &negWeight, MinReps: 8, MaxReps: 8, CompletedReps: &completedReps, CompletedAt: nil},
+						},
+					},
+				},
+			},
+		}
+
+		gen, err := newGenerator(preferences, history, pool)
+		if err != nil {
+			t.Fatalf("Failed to create generator: %v", err)
+		}
+
+		nextSession, err := gen.Generate(nextWorkoutDate)
+		if err != nil {
+			t.Fatalf("Failed to generate session: %v", err)
+		}
+
+		for _, es := range nextSession.ExerciseSets {
+			if es.ExerciseID != assistedExercise.ID {
+				continue
+			}
+			for i, set := range es.Sets {
+				if set.WeightKg == nil {
+					t.Errorf("Set %d: expected non-nil WeightKg", i)
+					continue
+				}
+				if *set.WeightKg <= negWeight {
+					t.Errorf("Set %d: expected weight > %f (less assistance) after success, got %f",
+						i, negWeight, *set.WeightKg)
+				}
+			}
+		}
+	})
 }

--- a/internal/workout/models.go
+++ b/internal/workout/models.go
@@ -21,6 +21,7 @@ type ExerciseType string
 const (
 	ExerciseTypeWeighted   ExerciseType = "weighted"
 	ExerciseTypeBodyweight ExerciseType = "bodyweight"
+	ExerciseTypeAssisted   ExerciseType = "assisted"
 )
 
 // Exercise represents a single exercise type, e.g. Squat, Bench Press, etc.
@@ -66,8 +67,8 @@ func (ejs exerciseJSONSchema) MarshalJSON() ([]byte, error) {
 			},
 			"exercise_type": map[string]any{
 				"type":        "string",
-				"description": "StartWorkout of exercise (weighted or bodyweight)",
-				"enum":        []string{"weighted", "bodyweight"},
+				"description": "Type of exercise (weighted, bodyweight, or assisted)",
+				"enum":        []string{"weighted", "bodyweight", "assisted"},
 			},
 			"description_markdown": map[string]any{
 				"type":        "string",

--- a/ui/templates/pages/exerciseset/exerciseset.gohtml
+++ b/ui/templates/pages/exerciseset/exerciseset.gohtml
@@ -447,7 +447,7 @@
                      role="group"
                      aria-label="Set {{ $index }}{{ if $set.CompletedReps }} completed{{ end }}">
                     <div class="set-info">
-                        {{ if eq $.ExerciseSet.Exercise.ExerciseType "weighted" }}
+                        {{ if or (eq $.ExerciseSet.Exercise.ExerciseType "weighted") (eq $.ExerciseSet.Exercise.ExerciseType "assisted") }}
                             <span class="weight"
                                   aria-label="Weight">{{ if $set.WeightKg }}{{ formatFloat $set.WeightKg }}{{ else }}0{{ end }} kg</span>
                         {{ end }}
@@ -467,13 +467,13 @@
                               class="set-form"
                               aria-label="Complete set {{ $index }}">
                             <div class="form-inputs">
-                                {{ if eq $.ExerciseSet.Exercise.ExerciseType "weighted" }}
+                                {{ if or (eq $.ExerciseSet.Exercise.ExerciseType "weighted") (eq $.ExerciseSet.Exercise.ExerciseType "assisted") }}
                                     <div class="input-field">
                                         <label for="weight-{{ $index }}">Weight (kg)</label>
                                         <input
                                                 id="weight-{{ $index }}"
                                                 inputmode="decimal"
-                                                pattern="[0-9,\.]*"
+                                                pattern="-?[0-9]*[,\.]?[0-9]*"
                                                 name="weight"
                                                 value="{{ if $set.WeightKg }}{{ formatFloat $set.WeightKg }}{{ else }}0{{ end }}"
                                                 step="0.5"

--- a/ui/templates/pages/exerciseset/exerciseset.gohtml
+++ b/ui/templates/pages/exerciseset/exerciseset.gohtml
@@ -302,6 +302,24 @@
                             }
                         }
 
+                        .sign-toggle-button {
+                            width: 5rem;
+                            padding: var(--size-1) var(--size-2);
+                            background: var(--color-info-bg);
+                            color: var(--color-info);
+                            border: 1px solid var(--color-info);
+                            border-radius: var(--radius-2);
+                            font-size: var(--font-size-0);
+                            font-weight: var(--font-weight-6);
+                            cursor: pointer;
+                            transition: background-color 0.2s ease;
+                            text-align: center;
+
+                            &:hover {
+                                background: var(--sky-1);
+                            }
+                        }
+
                         .submit-button {
                             padding: var(--size-3) var(--size-5);
                             background: var(--color-success);
@@ -347,6 +365,14 @@
 
             initializeTimer()
           })
+
+          function toggleWeightSign(inputId) {
+            const input = document.getElementById(inputId)
+            const value = parseFloat(input.value.replace(',', '.'))
+            if (!isNaN(value)) {
+              input.value = (-value).toString()
+            }
+          }
 
           function initializeTimer() {
             const timerDisplay = document.getElementById('workout-timer')
@@ -480,6 +506,12 @@
                                                 required
                                                 aria-describedby="weight-help-{{ $index }}"
                                         >
+                                        {{ if eq $.ExerciseSet.Exercise.ExerciseType "assisted" }}
+                                            <button type="button"
+                                                    class="sign-toggle-button"
+                                                    aria-label="Flip weight sign (for assisted exercises where assistance is negative)"
+                                                    onclick="toggleWeightSign('weight-{{ $index }}')">± Flip sign</button>
+                                        {{ end }}
                                         <div id="weight-help-{{ $index }}" class="sr-only">Enter weight in kilograms
                                         </div>
                                     </div>


### PR DESCRIPTION
Implements `specs/assisted-exercises.md` across all 5 PRs:

- **DB schema**: Add 'assisted' exercise type, remove `weight_kg >= 0` constraint
- **Domain model**: Add `ExerciseTypeAssisted` constant, update AI JSON schema
- **Progression**: Fix `reduceWeight()` for negative weights, add assisted default sets at 0 kg
- **HTTP handler**: Extend weight parsing and update for assisted type
- **UI template**: Show weight input for assisted exercises, allow minus sign in pattern
- **Seed data**: Add Assisted Pull-Up exercise

Closes #60

Generated with [Claude Code](https://claude.ai/code)