### PR TITLE
Fix rounding error showing 62.54 instead of 62.5 in exercise set form

### DIFF
--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"html/template"
+	"math"
 	"net/http"
 	"strconv"
 
@@ -12,9 +13,11 @@ import (
 )
 
 // formatFloat formats a float to remove trailing zeros and unnecessary precision.
-// This handles the floating point rounding errors like 60.900000000000006.
+// Rounds to one decimal place to avoid floating-point artifacts from weight calculations
+// (e.g., multiplying by factors like 0.85 can produce 62.54 instead of 62.5).
 func formatFloat(f float64) string {
-	return strconv.FormatFloat(f, 'f', -1, 64)
+	rounded := math.Round(f*10) / 10 //nolint:mnd // 10 = one decimal place precision
+	return strconv.FormatFloat(rounded, 'f', -1, 64)
 }
 
 // baseTemplateFuncs returns the base template.FuncMap with placeholder implementations.

--- a/cmd/web/handlers_test.go
+++ b/cmd/web/handlers_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_formatFloat(t *testing.T) {
+	tests := []struct {
+		input float64
+		want  string
+	}{
+		{62.54, "62.5"},               // weight progression artifact (0.85 factor)
+		{60.900000000000006, "60.9"},  // original floating-point artifact
+		{75.0, "75"},                  // whole number, no trailing zero
+		{0.0, "0"},                    // zero
+		{100.0, "100"},                // larger whole number
+		{62.5, "62.5"},               // already at one decimal place
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.input), func(t *testing.T) {
+			if got := formatFloat(tt.input); got != tt.want {
+				t.Errorf("formatFloat(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Round weight values to one decimal place in `formatFloat` to avoid floating-point artifacts from weight progression calculations.

Fixes #62

Generated with [Claude Code](https://claude.ai/code)