### PR TITLE
fix: show completed status when all sets done without session flag

### DIFF
--- a/cmd/web/handler-home.go
+++ b/cmd/web/handler-home.go
@@ -92,16 +92,21 @@ type workoutAction struct {
 }
 
 // determineWorkoutStatus determines the workout status based on session data and schedule.
-func determineWorkoutStatus(session workout.Session, isScheduled bool) string {
+// Sets completed on a day other than the scheduled date still count toward progress, so session-level
+// StartedAt/CompletedAt are not the sole source of truth.
+func determineWorkoutStatus(session workout.Session, isScheduled bool, completedSets, totalSets int) string {
+	allSetsCompleted := totalSets > 0 && completedSets == totalSets
+	hasStarted := !session.StartedAt.IsZero() || completedSets > 0
+
 	switch {
-	case !isScheduled && session.StartedAt.IsZero():
-		return statusUnscheduled
-	case session.StartedAt.IsZero():
-		return statusNotStarted
-	case session.CompletedAt.IsZero():
-		return statusInProgress
-	default:
+	case !session.CompletedAt.IsZero() || allSetsCompleted:
 		return statusCompleted
+	case hasStarted:
+		return statusInProgress
+	case !isScheduled:
+		return statusUnscheduled
+	default:
+		return statusNotStarted
 	}
 }
 
@@ -216,8 +221,8 @@ func toDays(sessions []workout.Session, preferences workout.Preferences) []dayVi
 		isToday := date.Format("2006-01-02") == today.Format("2006-01-02")
 		isPast := date.Before(today)
 
-		workoutStatus := determineWorkoutStatus(session, isScheduled)
 		completedSets, totalSets, progressPercent := calculateProgress(session)
+		workoutStatus := determineWorkoutStatus(session, isScheduled, completedSets, totalSets)
 		difficultyStars := prepareDifficultyStars(session.DifficultyRating)
 		status, statusLabel := calculateDisplayStatus(workoutStatus, isToday, isPast)
 		action := calculateWorkoutAction(status, isToday)

--- a/cmd/web/handler-home_status_test.go
+++ b/cmd/web/handler-home_status_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/myrjola/petrapp/internal/workout"
+)
+
+func TestDetermineWorkoutStatus(t *testing.T) {
+	now := time.Now()
+	newSession := func(startedAt, completedAt time.Time) workout.Session {
+		return workout.Session{
+			Date:              time.Time{},
+			DifficultyRating:  nil,
+			StartedAt:         startedAt,
+			CompletedAt:       completedAt,
+			ExerciseSets:      nil,
+			PeriodizationType: "",
+		}
+	}
+
+	tests := []struct {
+		name          string
+		session       workout.Session
+		isScheduled   bool
+		completedSets int
+		totalSets     int
+		want          string
+	}{
+		{
+			name:          "scheduled day with no activity",
+			session:       newSession(time.Time{}, time.Time{}),
+			isScheduled:   true,
+			completedSets: 0,
+			totalSets:     9,
+			want:          statusNotStarted,
+		},
+		{
+			name:          "unscheduled day with no activity",
+			session:       newSession(time.Time{}, time.Time{}),
+			isScheduled:   false,
+			completedSets: 0,
+			totalSets:     0,
+			want:          statusUnscheduled,
+		},
+		{
+			name:          "session started but no sets done",
+			session:       newSession(now, time.Time{}),
+			isScheduled:   true,
+			completedSets: 0,
+			totalSets:     9,
+			want:          statusInProgress,
+		},
+		{
+			name:          "some sets completed without StartedAt set",
+			session:       newSession(time.Time{}, time.Time{}),
+			isScheduled:   true,
+			completedSets: 3,
+			totalSets:     9,
+			want:          statusInProgress,
+		},
+		{
+			name:          "all sets completed without CompletedAt set",
+			session:       newSession(time.Time{}, time.Time{}),
+			isScheduled:   true,
+			completedSets: 9,
+			totalSets:     9,
+			want:          statusCompleted,
+		},
+		{
+			name:          "session formally completed",
+			session:       newSession(now, now),
+			isScheduled:   true,
+			completedSets: 9,
+			totalSets:     9,
+			want:          statusCompleted,
+		},
+		{
+			name:          "session completed flag set even without any sets logged",
+			session:       newSession(time.Time{}, now),
+			isScheduled:   true,
+			completedSets: 0,
+			totalSets:     9,
+			want:          statusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineWorkoutStatus(tt.session, tt.isScheduled, tt.completedSets, tt.totalSets)
+			if got != tt.want {
+				t.Errorf("determineWorkoutStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A workout completed on a later day (via Start Late) recorded set-level
CompletedAt but never set session.StartedAt, leaving the status logic
stuck on "not started" and showing the day as MISSED despite 9/9 sets.

Treat a session as completed when every set is done, and as in-progress
when any set has been done, independent of the session-level flags.