### PR TITLE
fix: anchor exercise starting weight to history before session date

### DIFF
--- a/internal/workout/repository-sessions.go
+++ b/internal/workout/repository-sessions.go
@@ -456,6 +456,39 @@ func (r *sqliteSessionRepository) ListSetsForExerciseSince(
 	return result, nil
 }
 
+// GetLatestStartingWeightBefore returns the weight of the first completed set
+// from the most recent session strictly before beforeDate. Returns 0 when no
+// completed history exists.
+func (r *sqliteSessionRepository) GetLatestStartingWeightBefore(
+	ctx context.Context,
+	exerciseID int,
+	beforeDate time.Time,
+) (float64, error) {
+	userID := contexthelpers.AuthenticatedUserID(ctx)
+	beforeDateStr := formatDate(beforeDate)
+
+	var weightKg float64
+	err := r.db.ReadOnly.QueryRowContext(ctx, `
+		SELECT weight_kg
+		FROM exercise_sets
+		WHERE workout_user_id = ?
+		  AND exercise_id = ?
+		  AND workout_date < ?
+		  AND completed_reps IS NOT NULL
+		  AND weight_kg IS NOT NULL
+		ORDER BY workout_date DESC, set_number ASC
+		LIMIT 1`,
+		userID, exerciseID, beforeDateStr).Scan(&weightKg)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("query latest starting weight: %w", err)
+	}
+
+	return weightKg, nil
+}
+
 // scanExerciseSetWithDate scans one row from the ListSetsForExerciseSince query.
 func (r *sqliteSessionRepository) scanExerciseSetWithDate(
 	rows *sql.Rows,

--- a/internal/workout/repository.go
+++ b/internal/workout/repository.go
@@ -59,6 +59,10 @@ type sessionRepository interface {
 	Update(ctx context.Context, date time.Time, updateFn func(sess *sessionAggregate) (bool, error)) error
 	// ListSetsForExerciseSince retrieves all sets for a given exercise since a date, one aggregate per session.
 	ListSetsForExerciseSince(ctx context.Context, exerciseID int, sinceDate time.Time) ([]datedExerciseSetAggregate, error)
+	// GetLatestStartingWeightBefore returns the weight of the first completed set
+	// from the most recent session strictly before beforeDate. Returns 0 when no
+	// completed history exists.
+	GetLatestStartingWeightBefore(ctx context.Context, exerciseID int, beforeDate time.Time) (float64, error)
 	// CountCompleted returns the count of sessions with completed_at IS NOT NULL.
 	CountCompleted(ctx context.Context) (int, error)
 	// CreateBatch creates multiple sessions atomically in a single transaction.

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -508,21 +508,16 @@ func (s *Service) GetExerciseSetsForExerciseSince(ctx context.Context, exerciseI
 	}, nil
 }
 
-// GetStartingWeight returns the weight from the first set of the most recent completed
-// session for the given exercise. Returns 0 if no completed history exists.
-func (s *Service) GetStartingWeight(ctx context.Context, exerciseID int) (float64, error) {
-	since := time.Now().AddDate(0, -3, 0)
-	aggs, err := s.repo.sessions.ListSetsForExerciseSince(ctx, exerciseID, since)
+// GetStartingWeight returns the weight of the first completed set from the most recent
+// session strictly before beforeDate. Using a cutoff keeps the starting weight stable
+// when earlier sets of beforeDate's session are edited. Returns 0 if no completed
+// history exists.
+func (s *Service) GetStartingWeight(ctx context.Context, exerciseID int, beforeDate time.Time) (float64, error) {
+	weight, err := s.repo.sessions.GetLatestStartingWeightBefore(ctx, exerciseID, beforeDate)
 	if err != nil {
-		return 0, fmt.Errorf("list sets for exercise: %w", err)
+		return 0, fmt.Errorf("get latest starting weight: %w", err)
 	}
-	// aggs is ordered DESC by date; first element is most recent session.
-	for _, agg := range aggs {
-		if len(agg.Sets) > 0 && agg.Sets[0].WeightKg != nil && agg.Sets[0].CompletedReps != nil {
-			return *agg.Sets[0].WeightKg, nil
-		}
-	}
-	return 0, nil
+	return weight, nil
 }
 
 // BuildProgression constructs an exerciseprogression.Progression for the given exercise
@@ -537,7 +532,7 @@ func (s *Service) BuildProgression(
 		return nil, fmt.Errorf("get session: %w", err)
 	}
 
-	startingWeight, err := s.GetStartingWeight(ctx, exerciseID)
+	startingWeight, err := s.GetStartingWeight(ctx, exerciseID, date)
 	if err != nil {
 		return nil, fmt.Errorf("get starting weight: %w", err)
 	}

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -588,8 +588,10 @@ func Test_GetStartingWeight(t *testing.T) {
 
 	svc := workout.NewService(db, logger, "")
 
+	today := time.Now()
+
 	// No history: expect 0.
-	got, err := svc.GetStartingWeight(ctx, exerciseID)
+	got, err := svc.GetStartingWeight(ctx, exerciseID, today)
 	if err != nil {
 		t.Fatalf("GetStartingWeight no history: %v", err)
 	}
@@ -597,8 +599,8 @@ func Test_GetStartingWeight(t *testing.T) {
 		t.Errorf("no history: want 0, got %v", got)
 	}
 
-	// Insert a completed session with set 1 weight = 60kg.
-	dateStr := time.Now().AddDate(0, 0, -7).Format("2006-01-02")
+	// Insert a completed session 7 days ago with set 1 weight = 60kg.
+	dateStr := today.AddDate(0, 0, -7).Format("2006-01-02")
 	_, err = db.ReadWrite.ExecContext(ctx,
 		"INSERT INTO workout_sessions (user_id, workout_date, completed_at) VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'))",
 		userID, dateStr)
@@ -614,12 +616,39 @@ func Test_GetStartingWeight(t *testing.T) {
 		t.Fatalf("insert set: %v", err)
 	}
 
-	got, err = svc.GetStartingWeight(ctx, exerciseID)
+	got, err = svc.GetStartingWeight(ctx, exerciseID, today)
 	if err != nil {
 		t.Fatalf("GetStartingWeight with history: %v", err)
 	}
 	if got != 60.0 {
 		t.Errorf("with history: want 60.0, got %v", got)
+	}
+
+	// Insert today's session with a different set 1 weight. The starting weight
+	// must remain anchored to the historical session, regardless of today's sets.
+	todayStr := today.Format("2006-01-02")
+	_, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO workout_sessions (user_id, workout_date, started_at) VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'))",
+		userID, todayStr)
+	if err != nil {
+		t.Fatalf("insert today's session: %v", err)
+	}
+	_, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO exercise_sets (workout_user_id, workout_date, exercise_id, set_number,
+		 weight_kg, min_reps, max_reps, completed_reps, signal)
+		 VALUES (?, ?, ?, 1, 75.0, 5, 5, 5, 'too_light'),
+		        (?, ?, ?, 2, 80.0, 5, 5, 5, 'on_target')`,
+		userID, todayStr, exerciseID, userID, todayStr, exerciseID)
+	if err != nil {
+		t.Fatalf("insert today's sets: %v", err)
+	}
+
+	got, err = svc.GetStartingWeight(ctx, exerciseID, today)
+	if err != nil {
+		t.Fatalf("GetStartingWeight ignoring today: %v", err)
+	}
+	if got != 60.0 {
+		t.Errorf("today ignored: want 60.0, got %v", got)
 	}
 }
 


### PR DESCRIPTION
The progression's starting weight was being recomputed from today's own
sets, so editing an earlier set could make it drift based on values
entered later. Replace the broad 3-month session scan with a dedicated
query that returns the first completed set's weight from the most recent
session strictly before the session date, so today's edits no longer
influence the baseline.

https://claude.ai/code/session_01KXHjc7qvhYk33dHSB84CTt