### PR TITLE
refactor(ui): introduce shared components folder with back-link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ A fitness tracking web application built with Go, SQLite, and server-side render
 
 ## Development Workflow
 
-When implementing features, follow this architectural flow:
+When a feature spans multiple layers, work outwards from the data model:
 
 1. **Database First** - Start with schema changes in `internal/sqlite/` (
    see [Database Guidelines](internal/sqlite/CLAUDE.md))
@@ -12,6 +12,13 @@ When implementing features, follow this architectural flow:
    see [Domain Guidelines](internal/workout/CLAUDE.md))
 3. **HTTP Layer** - Add handlers and routing in `cmd/web/` (see [Web Guidelines](cmd/web/CLAUDE.md))
 4. **Templates & UI** - Build frontend in `ui/templates/` (see [Template Guidelines](ui/templates/CLAUDE.md))
+
+If a change is scoped to one or two layers (e.g. a UI-only tweak or a handler-only bug fix), start at the lowest relevant layer — you don't have to touch the ones above.
+
+## Runtime Layout
+
+- Templates (`ui/templates/`) and static assets (`ui/static/`) are loaded from the filesystem at runtime (`os.DirFS`, not `//go:embed`). Editing a template and refreshing the browser is the whole dev loop — no rebuild needed.
+- In the Docker image, `main.css` and `main.js` are fingerprinted with an md5 hash at build time and `base.gohtml` is rewritten to reference the hashed names (see `Dockerfile`). Other static files (`webauthn.js`, icons) are served under their original names.
 
 ## Build & Run Commands
 

--- a/cmd/web/CLAUDE.md
+++ b/cmd/web/CLAUDE.md
@@ -21,7 +21,14 @@ Guidelines for working with HTTP handlers, routing, middleware, and web server c
 
 - Create dedicated structs for each template that embed `BaseTemplateData`
 - Transform all data in handlers before passing to templates - avoid complex template logic
-- Use `newBaseTemplateData(r)` to create base data with security context
+- Use `newBaseTemplateData(r)` to populate the embed from request context
+
+`BaseTemplateData` (defined in `templates.go`) exposes two fields that every page template can read:
+
+- `Authenticated bool` — set from `contexthelpers.IsAuthenticated(r.Context())`
+- `IsAdmin bool` — set from `contexthelpers.IsAdmin(r.Context())`
+
+The CSP nonce and CSRF plumbing do **not** travel on this struct — the nonce is injected as a template function (`{{ nonce }}`) via `contextTemplateFuncs` in `handlers.go`, and CSRF is handled in middleware. Anything that renders outside `app.render(...)` needs to wire those in explicitly.
 
 Example:
 
@@ -112,6 +119,8 @@ if fieldValue == "" {
 
 ## Testing with e2etest
 
+The `e2etest` package (`internal/e2etest/`) provides a real HTTP server bound to a random port plus a `Client` with cookie jar and form helpers. Handler tests use it instead of `httptest` so session middleware, CSRF, and the full middleware stack are exercised.
+
 ### End-to-End Testing Pattern
 
 ```go
@@ -121,6 +130,11 @@ if err != nil {
 }
 client := server.Client()
 ```
+
+Key entry points:
+
+- `e2etest.StartServer(ctx, out, lookupEnv, runFn) (*Server, error)` — `server.go`
+- `(*Client).SubmitForm(ctx, doc, actionPath, fields) (*goquery.Document, error)` — `client.go`; resolves the form by `action`, fills matching labels/fields, submits, returns the parsed response
 
 ### DOM Testing with goquery
 
@@ -176,6 +190,8 @@ if doc.Find("h1:contains('Add Exercise')").Length() == 0 {
 
 ### Route Registration
 
-- Group related routes together in routes.go
+- Routing uses the stdlib `http.ServeMux` with Go 1.22+ method+pattern syntax (e.g. `mux.Handle("GET /workouts/{date}", ...)`). No third-party router.
+- Path parameters are read with `r.PathValue("name")` inside the handler
+- Group related routes together in `routes.go`
 - Use descriptive route patterns that map to handler names
-- Include HTTP method constraints in routing configuration
+- Include HTTP method constraints in the pattern (`GET`, `POST`, etc.) — ServeMux returns 405 automatically for mismatches

--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -51,12 +51,17 @@ func (app *application) contextTemplateFuncs(ctx context.Context) template.FuncM
 // pageTemplate returns a template for the given page name.
 //
 // pageName corresponds to directory inside ui/templates/pages folder. It has to include a template named "page".
+// Shared component templates from ui/templates/components are also parsed and available to every page.
 func (app *application) pageTemplate(pageName string) (*template.Template, error) {
 	var err error
 	// We need to initialize the FuncMap before parsing the files. These will be overridden in the render function.
 	var t *template.Template
 	t = template.New(pageName).Funcs(app.baseTemplateFuncs())
-	if t, err = t.ParseFS(app.templateFS, "base.gohtml", fmt.Sprintf("pages/%s/*.gohtml", pageName)); err != nil {
+	if t, err = t.ParseFS(app.templateFS,
+		"base.gohtml",
+		"components/*.gohtml",
+		fmt.Sprintf("pages/%s/*.gohtml", pageName),
+	); err != nil {
 		return nil, fmt.Errorf("new template: %w", err)
 	}
 	return t, nil

--- a/internal/sqlite/CLAUDE.md
+++ b/internal/sqlite/CLAUDE.md
@@ -15,7 +15,7 @@ Guidelines for working with database schema, migrations, and data access pattern
 2. **Update Go models** in both domain (`internal/workout/models.go`) and repository layer
 3. **Update repository SQL queries** (SELECT, INSERT, UPDATE) to include new fields
 4. **Update service layer** conversion functions between domain and repository types
-5. **Test with `make test` to ensure migrations and queries work correctly
+5. **Test with `make test`** to ensure migrations and queries work correctly
 6. **Add test fixtures** in `fixtures.sql` if needed for new data that needs to be seeded
 
 ## Table Design Patterns
@@ -63,9 +63,14 @@ END;
 
 ### Foreign Key Patterns
 
+Match the FK column type to the referenced primary key. In this schema `users.id` is `INTEGER` and `credentials.id` is `BLOB` (WebAuthn credential ID), so pick accordingly:
+
 ```sql
--- Standard foreign key with cascade
-user_id BLOB NOT NULL REFERENCES users (id) ON DELETE CASCADE
+-- Standard foreign key with cascade (users.id is INTEGER)
+user_id INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE
+
+-- BLOB foreign key when referencing credentials.id
+credential_id BLOB NOT NULL REFERENCES credentials (id) ON DELETE CASCADE
 
 -- Deferred foreign key (for complex relationships)
 FOREIGN KEY (exercise_id) REFERENCES exercises (id) DEFERRABLE INITIALLY DEFERRED

--- a/internal/workout/CLAUDE.md
+++ b/internal/workout/CLAUDE.md
@@ -112,9 +112,9 @@ func (s *Service) StartWorkout(ctx context.Context, date time.Time) error {
 
 ### Error Handling
 
-- Use sentinel errors for business conditions: `var ErrNotFound = sql.ErrNoRows`
+- Use sentinel errors for business conditions. The package currently exposes `ErrNotFound` (`repository.go`) aliased to `sql.ErrNoRows`
 - Wrap errors with context: `fmt.Errorf("operation description: %w", err)`
-- Check for specific errors using `errors.Is(err, ErrNotFound)`
+- Check for specific errors using `errors.Is(err, workout.ErrNotFound)`
 - Let service layer handle business validation, repository handles data access
 
 ### Context Propagation
@@ -176,24 +176,24 @@ err := s.repo.sessions.Update(ctx, date, func(sess *sessionAggregate) (bool, err
 ```go
 // Convert repository aggregate to domain model
 func (r *repository) aggregateToDomain(agg sessionAggregate, exercises []Exercise) (Session, error) {
-session := Session{
-Date:             agg.Date,
-DifficultyRating: agg.DifficultyRating,
-StartedAt:        agg.StartedAt,
-CompletedAt:      agg.CompletedAt,
-}
+    session := Session{
+        Date:             agg.Date,
+        DifficultyRating: agg.DifficultyRating,
+        StartedAt:        agg.StartedAt,
+        CompletedAt:      agg.CompletedAt,
+    }
 
-// Build exercise sets with domain exercises
-for _, setAgg := range agg.ExerciseSets {
-exercise := findExerciseByID(exercises, setAgg.ExerciseID)
-session.ExerciseSets = append(session.ExerciseSets, ExerciseSet{
-Exercise:          exercise,
-Sets:              setAgg.Sets,
-WarmupCompletedAt: setAgg.WarmupCompletedAt,
-})
-}
+    // Build exercise sets with domain exercises
+    for _, setAgg := range agg.ExerciseSets {
+        exercise := findExerciseByID(exercises, setAgg.ExerciseID)
+        session.ExerciseSets = append(session.ExerciseSets, ExerciseSet{
+            Exercise:          exercise,
+            Sets:              setAgg.Sets,
+            WarmupCompletedAt: setAgg.WarmupCompletedAt,
+        })
+    }
 
-return session, nil
+    return session, nil
 }
 ```
 
@@ -242,18 +242,17 @@ return session, nil
 
 ### Business Rule Violations
 
-```go
-// Define sentinel errors for business conditions
-var (
-    ErrWorkoutAlreadyStarted   = errors.New("workout already started")
-    ErrWorkoutNotFound        = errors.New("workout not found")
-    ErrInvalidDifficultyRating = errors.New("difficulty rating must be 1-5")
-)
+Today the package exposes a single sentinel error, defined in `repository.go`:
 
-// Check for specific errors in handlers
-if errors.Is(err, ErrWorkoutNotFound) {
-    // Handle not found case specifically
-}
+```go
+// ErrNotFound is returned when a record is not found.
+var ErrNotFound = sql.ErrNoRows
+```
+
+Handlers and callers check it with `errors.Is(err, workout.ErrNotFound)`. If you need a new sentinel for a business condition (e.g. "workout already started"), follow the `Err` prefix convention from the root CLAUDE.md:
+
+```go
+var ErrWorkoutAlreadyStarted = errors.New("workout already started")
 ```
 
 ### Validation and Input Sanitization

--- a/ui/static/main.css
+++ b/ui/static/main.css
@@ -258,6 +258,30 @@
     }
 
 
+    /* Back-link component (ui/templates/components/back-link.gohtml).
+       Pages that need a different look can still override via scoped styles. */
+    .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--size-1);
+        padding: var(--size-2) var(--size-3);
+        border-radius: var(--radius-2);
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        font-weight: var(--font-weight-5);
+        transition: background-color 0.2s ease, color 0.2s ease;
+
+        &:hover {
+            background: var(--gray-1);
+            color: var(--color-text-primary);
+        }
+
+        &:focus-visible {
+            outline: var(--color-border-focus) solid 2px;
+            outline-offset: 2px;
+        }
+    }
+
     /* Screen reader only content */
     .sr-only {
         position: absolute;

--- a/ui/static/main.css
+++ b/ui/static/main.css
@@ -258,30 +258,6 @@
     }
 
 
-    /* Back-link component (ui/templates/components/back-link.gohtml).
-       Pages that need a different look can still override via scoped styles. */
-    .back-link {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--size-1);
-        padding: var(--size-2) var(--size-3);
-        border-radius: var(--radius-2);
-        color: var(--color-text-secondary);
-        text-decoration: none;
-        font-weight: var(--font-weight-5);
-        transition: background-color 0.2s ease, color 0.2s ease;
-
-        &:hover {
-            background: var(--gray-1);
-            color: var(--color-text-primary);
-        }
-
-        &:focus-visible {
-            outline: var(--color-border-focus) solid 2px;
-            outline-offset: 2px;
-        }
-    }
-
     /* Screen reader only content */
     .sr-only {
         position: absolute;

--- a/ui/templates/CLAUDE.md
+++ b/ui/templates/CLAUDE.md
@@ -62,13 +62,14 @@ Guidelines for working with Go templates, CSS architecture, and design systems i
   {{ template "back-link" "/" }}
   {{ template "back-link" (printf "/workouts/%s" (.Date.Format "2006-01-02")) }}
   ```
-  Styled globally in `main.css` under `@layer components`. Pages that need a different look can still override via their own `@scope` block.
+  Self-contained: styles live in the component file as a scoped `<style {{ nonce }}>` block.
 
 ### Styling Components
 
-- Global component CSS goes in `main.css` under `@layer components` with a class that matches the component's purpose
-- Pages can override component styling with their own `@scope { :scope { ... } }` block — scoped styles outrank layered ones
-- If a component needs dynamic styling from template context, inline a `<style {{ nonce }}>` block inside the component's markup
+- **Colocate styles with markup.** Put a `<style {{ nonce }}>` block as the first child of the component's root element and use a bare `@scope { :scope { ... } }` — the default scope root is the `<style>` tag's parent, so styles apply only to this instance of the component
+- The whole component — markup and styles — lives in one file. Delete the file to delete the feature; nothing to hunt down in `main.css`
+- If a component is rendered many times on the same page and the duplicated `<style>` tag becomes a real cost, hoist the rule to `main.css` under `@layer components` (measure first; gzip makes duplicate inline `<style>` blocks cheap)
+- Only add rules to `main.css` if they need to apply to markup outside the component — otherwise keep them local
 
 ## Available Template Functions
 

--- a/ui/templates/CLAUDE.md
+++ b/ui/templates/CLAUDE.md
@@ -9,7 +9,7 @@ Guidelines for working with Go templates, CSS architecture, and design systems i
 - Page templates are organized in `/ui/templates/pages/{pageName}/` folders
 - Each page template defines a `{{ define "page" }}` block
 - All pages extend the base template which provides the HTML structure
-- Include gotype comments at the top: `{{- /*gotype: github.com/myrjola/petrapp/cmd/web.TemplateDataType*/ -}}`
+- Include gotype comments at the top: `{{- /*gotype: github.com/myrjola/petrapp/cmd/web.TemplateDataType*/ -}}`. This is read by the JetBrains Go Template plugin to give type-aware completion inside the template. Keep the fully-qualified struct path in sync when you rename the Go type — nothing will fail to compile if it drifts, but IDE hints will silently go stale
 - Reusable components live in `/ui/templates/components/` and are available to every page automatically — see "Shared Components" below
 
 ### JavaScript in Templates
@@ -66,7 +66,7 @@ Guidelines for working with Go templates, CSS architecture, and design systems i
 
 ### Styling Components
 
-- **Colocate styles with markup.** Put a `<style {{ nonce }}>` block as the first child of the component's root element and use a bare `@scope { :scope { ... } }` — the default scope root is the `<style>` tag's parent, so styles apply only to this instance of the component
+- **Colocate styles with markup.** Put a `<style {{ nonce }}>` block inside the component's root element and use a bare `@scope { :scope { ... } }` — the default scope root is the `<style>` tag's parent, so styles apply only to this instance of the component (position among siblings doesn't matter)
 - The whole component — markup and styles — lives in one file. Delete the file to delete the feature; nothing to hunt down in `main.css`
 - If a component is rendered many times on the same page and the duplicated `<style>` tag becomes a real cost, hoist the rule to `main.css` under `@layer components` (measure first; gzip makes duplicate inline `<style>` blocks cheap)
 - Only add rules to `main.css` if they need to apply to markup outside the component — otherwise keep them local
@@ -157,7 +157,8 @@ Always verify these exist in `main.css` before using:
 - **Radius**: `--radius-1` through `--radius-6`, `--radius-round`
 - **Border sizes**: `--border-size-1` through `--border-size-5`
 - **Font weights**: `--font-weight-1` through `--font-weight-9`
-- **Font sizes**: `--font-size-0` through `--font-size-8`
+- **Font sizes**: `--font-size-00` (0.5rem) and `--font-size-0` through `--font-size-8`
+- **Fluid font sizes**: `--font-size-fluid-0` through `--font-size-fluid-3` (responsive via `clamp()`)
 
 ### Color Usage Patterns
 
@@ -195,6 +196,11 @@ The project uses CSS layers defined in main.css:
 - Use range loops for iteration, basic if/else for display logic
 - For complex formatting or calculations, prepare data in handlers
 - Avoid nested template logic - flatten data structures in Go code instead
+
+### URL Construction
+
+- Inline `printf` for URL formatting is fine and idiomatic here: `{{ printf "/workouts/%s/exercises/%d" (.Date.Format "2006-01-02") .Exercise.ID }}`
+- Only pre-build URLs in the handler when the same URL is used in several places on the page, or the path depends on non-trivial logic
 
 ### Common Transformation Examples
 

--- a/ui/templates/CLAUDE.md
+++ b/ui/templates/CLAUDE.md
@@ -10,6 +10,7 @@ Guidelines for working with Go templates, CSS architecture, and design systems i
 - Each page template defines a `{{ define "page" }}` block
 - All pages extend the base template which provides the HTML structure
 - Include gotype comments at the top: `{{- /*gotype: github.com/myrjola/petrapp/cmd/web.TemplateDataType*/ -}}`
+- Reusable components live in `/ui/templates/components/` and are available to every page automatically — see "Shared Components" below
 
 ### JavaScript in Templates
 
@@ -38,6 +39,36 @@ Guidelines for working with Go templates, CSS architecture, and design systems i
 - Template name corresponds to folder name in `pages/`
 - Base template wraps page content and provides shared HTML structure
 - Page-specific templates focus only on content within `<main>`
+
+## Shared Components
+
+### Where Components Live
+
+- Component templates live in `/ui/templates/components/*.gohtml`
+- Every file in this folder is parsed alongside every page, so any `{{ define "component-name" }}` block defined here is callable from any page via `{{ template "component-name" <data> }}`
+- One component per file; the filename should match the defined template name (e.g. `back-link.gohtml` defines `back-link`)
+- Keep the dot (`.`) passed to a component minimal — a string, a small struct — not the whole page data
+
+### When to Add a Component
+
+- **Extract only when real duplication exists.** Three nearly-identical sites is the threshold. Two is borderline; one is premature.
+- Prefer small, presentational components (anchors, buttons, banners) over wrappers that try to capture layout
+- If two candidate usages differ in more than trivial attributes (label wording, icon presence), consider whether they're really the same component or just look similar
+
+### Current Components
+
+- `back-link` — canonical "← Back" anchor wired into the Navigation API via `data-back-button`. Takes an href string as the dot.
+  ```gohtml
+  {{ template "back-link" "/" }}
+  {{ template "back-link" (printf "/workouts/%s" (.Date.Format "2006-01-02")) }}
+  ```
+  Styled globally in `main.css` under `@layer components`. Pages that need a different look can still override via their own `@scope` block.
+
+### Styling Components
+
+- Global component CSS goes in `main.css` under `@layer components` with a class that matches the component's purpose
+- Pages can override component styling with their own `@scope { :scope { ... } }` block — scoped styles outrank layered ones
+- If a component needs dynamic styling from template context, inline a `<style {{ nonce }}>` block inside the component's markup
 
 ## Available Template Functions
 

--- a/ui/templates/CLAUDE.md
+++ b/ui/templates/CLAUDE.md
@@ -66,7 +66,9 @@ Guidelines for working with Go templates, CSS architecture, and design systems i
 
 ### Styling Components
 
-- **Colocate styles with markup.** Put a `<style {{ nonce }}>` block inside the component's root element and use a bare `@scope { :scope { ... } }` — the default scope root is the `<style>` tag's parent, so styles apply only to this instance of the component (position among siblings doesn't matter)
+- **Colocate styles with markup.** Emit a `<style {{ nonce }}>` block as a sibling immediately preceding the component root (not inside it — `<style>` is metadata content and is non-conforming inside interactive content like `<a>`, `<button>`, or form controls)
+- Use `@scope (<selector>) { :scope { ... } }` with a class or data attribute that uniquely identifies the component root. Example: `@scope (.back-link) { :scope { ... } }`
+- Pages that render their own elements matching the same selector will still override the component's rules via their own unlayered inline `<style>` blocks — unlayered wins by cascade proximity / source order
 - The whole component — markup and styles — lives in one file. Delete the file to delete the feature; nothing to hunt down in `main.css`
 - If a component is rendered many times on the same page and the duplicated `<style>` tag becomes a real cost, hoist the rule to `main.css` under `@layer components` (measure first; gzip makes duplicate inline `<style>` blocks cheap)
 - Only add rules to `main.css` if they need to apply to markup outside the component — otherwise keep them local

--- a/ui/templates/components/back-link.gohtml
+++ b/ui/templates/components/back-link.gohtml
@@ -8,34 +8,34 @@
         {{ template "back-link" "/" }}
         {{ template "back-link" (printf "/workouts/%s" (.Date.Format "2006-01-02")) }}
 */ -}}
-{{ define "back-link" }}
-    <a href="{{ . }}" data-back-button class="back-link">
-        <style {{ nonce }}>
-            @scope {
-                :scope {
-                    display: inline-flex;
-                    align-items: center;
-                    gap: var(--size-1);
-                    padding: var(--size-2) var(--size-3);
-                    border-radius: var(--radius-2);
-                    color: var(--color-text-secondary);
-                    text-decoration: none;
-                    font-weight: var(--font-weight-5);
-                    transition: background-color 0.2s ease, color 0.2s ease;
+{{- define "back-link" -}}
+    <style {{ nonce }}>
+        @scope (.back-link) {
+            :scope {
+                display: inline-flex;
+                align-items: center;
+                gap: var(--size-1);
+                padding: var(--size-2) var(--size-3);
+                border-radius: var(--radius-2);
+                color: var(--color-text-secondary);
+                text-decoration: none;
+                font-weight: var(--font-weight-5);
+                transition: background-color 0.2s ease, color 0.2s ease;
 
-                    &:hover {
-                        background: var(--gray-1);
-                        color: var(--color-text-primary);
-                    }
+                &:hover {
+                    background: var(--gray-1);
+                    color: var(--color-text-primary);
+                }
 
-                    &:focus-visible {
-                        outline: var(--color-border-focus) solid 2px;
-                        outline-offset: 2px;
-                    }
+                &:focus-visible {
+                    outline: var(--color-border-focus) solid 2px;
+                    outline-offset: 2px;
                 }
             }
-        </style>
+        }
+    </style>
+    <a href="{{ . }}" data-back-button class="back-link">
         <span aria-hidden="true">←</span>
         <span>Back</span>
     </a>
-{{ end }}
+{{- end }}

--- a/ui/templates/components/back-link.gohtml
+++ b/ui/templates/components/back-link.gohtml
@@ -1,0 +1,16 @@
+{{- /*
+    back-link: anchor styled as a back button, wired into the Navigation API
+    smart-back-button behaviour via the data-back-button attribute.
+
+    Pass the href string as the dot. For a non-default label, use back-link-labelled.
+
+    Usage:
+        {{ template "back-link" "/" }}
+        {{ template "back-link" (printf "/workouts/%s" (.Date.Format "2006-01-02")) }}
+*/ -}}
+{{ define "back-link" }}
+    <a href="{{ . }}" data-back-button class="back-link">
+        <span aria-hidden="true">←</span>
+        <span>Back</span>
+    </a>
+{{ end }}

--- a/ui/templates/components/back-link.gohtml
+++ b/ui/templates/components/back-link.gohtml
@@ -2,7 +2,7 @@
     back-link: anchor styled as a back button, wired into the Navigation API
     smart-back-button behaviour via the data-back-button attribute.
 
-    Pass the href string as the dot. For a non-default label, use back-link-labelled.
+    Pass the href string as the dot.
 
     Usage:
         {{ template "back-link" "/" }}
@@ -10,6 +10,31 @@
 */ -}}
 {{ define "back-link" }}
     <a href="{{ . }}" data-back-button class="back-link">
+        <style {{ nonce }}>
+            @scope {
+                :scope {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: var(--size-1);
+                    padding: var(--size-2) var(--size-3);
+                    border-radius: var(--radius-2);
+                    color: var(--color-text-secondary);
+                    text-decoration: none;
+                    font-weight: var(--font-weight-5);
+                    transition: background-color 0.2s ease, color 0.2s ease;
+
+                    &:hover {
+                        background: var(--gray-1);
+                        color: var(--color-text-primary);
+                    }
+
+                    &:focus-visible {
+                        outline: var(--color-border-focus) solid 2px;
+                        outline-offset: 2px;
+                    }
+                }
+            }
+        </style>
         <span aria-hidden="true">←</span>
         <span>Back</span>
     </a>

--- a/ui/templates/pages/exercise-add/exercise-add.gohtml
+++ b/ui/templates/pages/exercise-add/exercise-add.gohtml
@@ -42,9 +42,7 @@
                     }
                 }
             </style>
-            <a href="/workouts/{{ .Date.Format "2006-01-02" }}" data-back-button>
-                ← Back
-            </a>
+            {{ template "back-link" (printf "/workouts/%s" (.Date.Format "2006-01-02")) }}
             <h1>Add Exercise</h1>
         </header>
 

--- a/ui/templates/pages/exercise-info/exercise-info.gohtml
+++ b/ui/templates/pages/exercise-info/exercise-info.gohtml
@@ -57,9 +57,7 @@
                     }
                 }
             </style>
-            <a href="/workouts/{{ .Date.Format "2006-01-02" }}/exercises/{{ .Exercise.ID }}" data-back-button>
-                ← Back
-            </a>
+            {{ template "back-link" (printf "/workouts/%s/exercises/%d" (.Date.Format "2006-01-02") .Exercise.ID) }}
             <h1>{{ .Exercise.Name }}</h1>
             {{ if .IsAdmin }}
                 <a href="/admin/exercises/{{ .Exercise.ID }}" class="admin-edit">Edit Exercise</a>

--- a/ui/templates/pages/exercise-swap/exercise-swap.gohtml
+++ b/ui/templates/pages/exercise-swap/exercise-swap.gohtml
@@ -42,9 +42,7 @@
                     }
                 }
             </style>
-            <a href="/workouts/{{ .Date.Format "2006-01-02" }}/exercises/{{ .CurrentExercise.ID }}" data-back-button>
-                ← Back
-            </a>
+            {{ template "back-link" (printf "/workouts/%s/exercises/%d" (.Date.Format "2006-01-02") .CurrentExercise.ID) }}
             <h1>Swap Exercise</h1>
         </header>
 

--- a/ui/templates/pages/preferences/preferences.gohtml
+++ b/ui/templates/pages/preferences/preferences.gohtml
@@ -250,7 +250,7 @@
                     }
                 }
             </style>
-            <a href="/" data-back-button>← Back</a>
+            {{ template "back-link" "/" }}
         </header>
 
         <h1 id="schedule-heading">Weekly Schedule</h1>


### PR DESCRIPTION
Adds ui/templates/components/ which is parsed alongside every page, so
any {{ define "name" }} block defined there is callable from any page.
The first component is back-link, a canonical "← Back" anchor wired
into the Navigation API. Four existing duplications are migrated to it
(preferences, exercise-add, exercise-info, exercise-swap). Pages with
specialised back-link styling (not-found, privacy, exerciseset,
admin-exercise-edit) are left as-is since they diverge intentionally.

https://claude.ai/code/session_013p6iXfWQ6ccnr9HbLWtnPb