### PR TITLE
feat(progression): translate starting weight across periodization phases

### DIFF
--- a/internal/exerciseprogression/conversion.go
+++ b/internal/exerciseprogression/conversion.go
@@ -1,0 +1,16 @@
+package exerciseprogression
+
+// ConvertWeight translates a load chosen for fromReps into an equivalent load
+// for toReps at the same estimated one-rep max, rounded to the nearest 0.5 kg.
+// It uses the Epley formula: 1RM = w * (1 + r/30).
+//
+// Returns weight unchanged when fromReps == toReps, or when any input is
+// non-positive.
+func ConvertWeight(weight float64, fromReps, toReps int) float64 {
+	if weight <= 0 || fromReps <= 0 || toReps <= 0 || fromReps == toReps {
+		return weight
+	}
+	oneRepMax := weight * (1 + float64(fromReps)/30)
+	converted := oneRepMax / (1 + float64(toReps)/30)
+	return roundToHalf(converted)
+}

--- a/internal/exerciseprogression/conversion_test.go
+++ b/internal/exerciseprogression/conversion_test.go
@@ -1,0 +1,118 @@
+package exerciseprogression_test
+
+import (
+	"testing"
+
+	"github.com/myrjola/petrapp/internal/exerciseprogression"
+)
+
+func TestConvertWeight(t *testing.T) {
+	tests := []struct {
+		name     string
+		weight   float64
+		fromReps int
+		toReps   int
+		want     float64
+	}{
+		{
+			name:     "same reps returns input unchanged",
+			weight:   100.0,
+			fromReps: 5,
+			toReps:   5,
+			want:     100.0,
+		},
+		{
+			name:     "strength 100kg x5 to hypertrophy 8 reps",
+			weight:   100.0,
+			fromReps: 5,
+			toReps:   8,
+			want:     92.0,
+		},
+		{
+			name:     "hypertrophy 80kg x8 to strength 5 reps",
+			weight:   80.0,
+			fromReps: 8,
+			toReps:   5,
+			want:     87.0,
+		},
+		{
+			name:     "strength 100kg x5 to endurance 15 reps",
+			weight:   100.0,
+			fromReps: 5,
+			toReps:   15,
+			want:     78.0,
+		},
+		{
+			name:     "endurance 60kg x15 to strength 5 reps",
+			weight:   60.0,
+			fromReps: 15,
+			toReps:   5,
+			want:     77.0,
+		},
+		{
+			name:     "result is rounded to nearest 0.5 kg",
+			weight:   42.5,
+			fromReps: 5,
+			toReps:   8,
+			want:     39.0,
+		},
+		{
+			name:     "zero weight returned unchanged",
+			weight:   0.0,
+			fromReps: 5,
+			toReps:   8,
+			want:     0.0,
+		},
+		{
+			name:     "negative weight returned unchanged",
+			weight:   -5.0,
+			fromReps: 5,
+			toReps:   8,
+			want:     -5.0,
+		},
+		{
+			name:     "zero fromReps returned unchanged",
+			weight:   100.0,
+			fromReps: 0,
+			toReps:   8,
+			want:     100.0,
+		},
+		{
+			name:     "zero toReps returned unchanged",
+			weight:   100.0,
+			fromReps: 5,
+			toReps:   0,
+			want:     100.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := exerciseprogression.ConvertWeight(tt.weight, tt.fromReps, tt.toReps)
+			if got != tt.want {
+				t.Errorf("ConvertWeight(%v, %d, %d) = %v; want %v",
+					tt.weight, tt.fromReps, tt.toReps, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTargetReps(t *testing.T) {
+	tests := []struct {
+		name string
+		p    exerciseprogression.PeriodizationType
+		want int
+	}{
+		{"strength", exerciseprogression.Strength, 5},
+		{"hypertrophy", exerciseprogression.Hypertrophy, 8},
+		{"endurance", exerciseprogression.Endurance, 15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := exerciseprogression.TargetReps(tt.p)
+			if got != tt.want {
+				t.Errorf("TargetReps(%v) = %d; want %d", tt.p, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/exerciseprogression/progression.go
+++ b/internal/exerciseprogression/progression.go
@@ -76,7 +76,7 @@ func NewFromHistory(config Config, completed []SetResult) *Progression {
 
 // CurrentSet returns the recommended target for the next set.
 func (p *Progression) CurrentSet() SetTarget {
-	reps := targetReps(p.config.Type)
+	reps := TargetReps(p.config.Type)
 	if len(p.completed) == 0 {
 		return SetTarget{WeightKg: p.config.StartingWeight, TargetReps: reps}
 	}
@@ -95,7 +95,8 @@ func (p *Progression) SetsCompleted() int {
 	return len(p.completed)
 }
 
-func targetReps(t PeriodizationType) int {
+// TargetReps returns the canonical target rep count for a periodization.
+func TargetReps(t PeriodizationType) int {
 	switch t {
 	case Strength:
 		return repsStrength

--- a/internal/workout/repository-sessions.go
+++ b/internal/workout/repository-sessions.go
@@ -457,36 +457,46 @@ func (r *sqliteSessionRepository) ListSetsForExerciseSince(
 }
 
 // GetLatestStartingWeightBefore returns the weight of the first completed set
-// from the most recent session strictly before beforeDate. Returns 0 when no
-// completed history exists.
+// from the most recent session strictly before beforeDate, along with that
+// session's periodization type. Returns a zero-value struct when no completed
+// history exists.
 func (r *sqliteSessionRepository) GetLatestStartingWeightBefore(
 	ctx context.Context,
 	exerciseID int,
 	beforeDate time.Time,
-) (float64, error) {
+) (LatestStartingSet, error) {
 	userID := contexthelpers.AuthenticatedUserID(ctx)
 	beforeDateStr := formatDate(beforeDate)
 
-	var weightKg float64
+	var (
+		weightKg   float64
+		periodType string
+	)
 	err := r.db.ReadOnly.QueryRowContext(ctx, `
-		SELECT weight_kg
-		FROM exercise_sets
-		WHERE workout_user_id = ?
-		  AND exercise_id = ?
-		  AND workout_date < ?
-		  AND completed_reps IS NOT NULL
-		  AND weight_kg IS NOT NULL
-		ORDER BY workout_date DESC, set_number ASC
+		SELECT es.weight_kg, ws.periodization_type
+		FROM exercise_sets es
+		JOIN workout_sessions ws
+		  ON ws.user_id = es.workout_user_id
+		 AND ws.workout_date = es.workout_date
+		WHERE es.workout_user_id = ?
+		  AND es.exercise_id = ?
+		  AND es.workout_date < ?
+		  AND es.completed_reps IS NOT NULL
+		  AND es.weight_kg IS NOT NULL
+		ORDER BY es.workout_date DESC, es.set_number ASC
 		LIMIT 1`,
-		userID, exerciseID, beforeDateStr).Scan(&weightKg)
+		userID, exerciseID, beforeDateStr).Scan(&weightKg, &periodType)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, nil
+			return LatestStartingSet{WeightKg: 0, PeriodizationType: ""}, nil
 		}
-		return 0, fmt.Errorf("query latest starting weight: %w", err)
+		return LatestStartingSet{WeightKg: 0, PeriodizationType: ""}, fmt.Errorf("query latest starting weight: %w", err)
 	}
 
-	return weightKg, nil
+	return LatestStartingSet{
+		WeightKg:          weightKg,
+		PeriodizationType: PeriodizationType(periodType),
+	}, nil
 }
 
 // scanExerciseSetWithDate scans one row from the ListSetsForExerciseSince query.

--- a/internal/workout/repository.go
+++ b/internal/workout/repository.go
@@ -48,6 +48,14 @@ type datedExerciseSetAggregate struct {
 	exerciseSetAggregate
 }
 
+// LatestStartingSet captures the weight of the most recent completed first set
+// for an exercise along with the periodization type of the session it came from.
+// PeriodizationType is empty when no history exists.
+type LatestStartingSet struct {
+	WeightKg          float64
+	PeriodizationType PeriodizationType
+}
+
 // sessionRepository handles workout sessions.
 type sessionRepository interface {
 	List(ctx context.Context, sinceDate time.Time) ([]sessionAggregate, error)
@@ -60,9 +68,10 @@ type sessionRepository interface {
 	// ListSetsForExerciseSince retrieves all sets for a given exercise since a date, one aggregate per session.
 	ListSetsForExerciseSince(ctx context.Context, exerciseID int, sinceDate time.Time) ([]datedExerciseSetAggregate, error)
 	// GetLatestStartingWeightBefore returns the weight of the first completed set
-	// from the most recent session strictly before beforeDate. Returns 0 when no
-	// completed history exists.
-	GetLatestStartingWeightBefore(ctx context.Context, exerciseID int, beforeDate time.Time) (float64, error)
+	// from the most recent session strictly before beforeDate, along with that
+	// session's periodization type. Returns a zero-value struct when no completed
+	// history exists.
+	GetLatestStartingWeightBefore(ctx context.Context, exerciseID int, beforeDate time.Time) (LatestStartingSet, error)
 	// CountCompleted returns the count of sessions with completed_at IS NOT NULL.
 	CountCompleted(ctx context.Context) (int, error)
 	// CreateBatch creates multiple sessions atomically in a single transaction.

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -508,16 +508,42 @@ func (s *Service) GetExerciseSetsForExerciseSince(ctx context.Context, exerciseI
 	}, nil
 }
 
-// GetStartingWeight returns the weight of the first completed set from the most recent
-// session strictly before beforeDate. Using a cutoff keeps the starting weight stable
-// when earlier sets of beforeDate's session are edited. Returns 0 if no completed
-// history exists.
-func (s *Service) GetStartingWeight(ctx context.Context, exerciseID int, beforeDate time.Time) (float64, error) {
-	weight, err := s.repo.sessions.GetLatestStartingWeightBefore(ctx, exerciseID, beforeDate)
+// GetStartingWeight returns the weight to seed a new session for the given exercise.
+// It pulls the first completed set from the most recent session strictly before
+// beforeDate, then converts the load via Epley 1RM-equivalence when that session's
+// periodization differs from targetType so the relative intensity carries across
+// rep schemes (e.g. 100 kg x5 strength → ~92 kg x8 hypertrophy). Using a cutoff
+// keeps the starting weight stable when earlier sets of beforeDate's session are
+// edited. Returns 0 if no completed history exists.
+func (s *Service) GetStartingWeight(
+	ctx context.Context,
+	exerciseID int,
+	beforeDate time.Time,
+	targetType PeriodizationType,
+) (float64, error) {
+	prev, err := s.repo.sessions.GetLatestStartingWeightBefore(ctx, exerciseID, beforeDate)
 	if err != nil {
 		return 0, fmt.Errorf("get latest starting weight: %w", err)
 	}
-	return weight, nil
+	if prev.PeriodizationType == "" || prev.PeriodizationType == targetType {
+		return prev.WeightKg, nil
+	}
+	fromReps := exerciseprogression.TargetReps(periodizationToProgression(prev.PeriodizationType))
+	toReps := exerciseprogression.TargetReps(periodizationToProgression(targetType))
+	return exerciseprogression.ConvertWeight(prev.WeightKg, fromReps, toReps), nil
+}
+
+// periodizationToProgression maps a workout periodization to its exerciseprogression
+// counterpart. Unknown values default to Strength.
+func periodizationToProgression(p PeriodizationType) exerciseprogression.PeriodizationType {
+	switch p {
+	case PeriodizationHypertrophy:
+		return exerciseprogression.Hypertrophy
+	case PeriodizationStrength:
+		return exerciseprogression.Strength
+	default:
+		return exerciseprogression.Strength
+	}
 }
 
 // BuildProgression constructs an exerciseprogression.Progression for the given exercise
@@ -532,18 +558,12 @@ func (s *Service) BuildProgression(
 		return nil, fmt.Errorf("get session: %w", err)
 	}
 
-	startingWeight, err := s.GetStartingWeight(ctx, exerciseID, date)
+	startingWeight, err := s.GetStartingWeight(ctx, exerciseID, date, sess.PeriodizationType)
 	if err != nil {
 		return nil, fmt.Errorf("get starting weight: %w", err)
 	}
 
-	var epType exerciseprogression.PeriodizationType
-	switch sess.PeriodizationType {
-	case PeriodizationHypertrophy:
-		epType = exerciseprogression.Hypertrophy
-	case PeriodizationStrength:
-		epType = exerciseprogression.Strength
-	}
+	epType := periodizationToProgression(sess.PeriodizationType)
 
 	config := exerciseprogression.Config{
 		Type:           epType,

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -591,7 +591,7 @@ func Test_GetStartingWeight(t *testing.T) {
 	today := time.Now()
 
 	// No history: expect 0.
-	got, err := svc.GetStartingWeight(ctx, exerciseID, today)
+	got, err := svc.GetStartingWeight(ctx, exerciseID, today, workout.PeriodizationStrength)
 	if err != nil {
 		t.Fatalf("GetStartingWeight no history: %v", err)
 	}
@@ -599,10 +599,11 @@ func Test_GetStartingWeight(t *testing.T) {
 		t.Errorf("no history: want 0, got %v", got)
 	}
 
-	// Insert a completed session 7 days ago with set 1 weight = 60kg.
+	// Insert a completed strength session 7 days ago with set 1 weight = 100kg x5.
 	dateStr := today.AddDate(0, 0, -7).Format("2006-01-02")
 	_, err = db.ReadWrite.ExecContext(ctx,
-		"INSERT INTO workout_sessions (user_id, workout_date, completed_at) VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'))",
+		`INSERT INTO workout_sessions (user_id, workout_date, completed_at, periodization_type)
+		 VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'), 'strength')`,
 		userID, dateStr)
 	if err != nil {
 		t.Fatalf("insert session: %v", err)
@@ -610,18 +611,29 @@ func Test_GetStartingWeight(t *testing.T) {
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_user_id, workout_date, exercise_id, set_number,
 		 weight_kg, min_reps, max_reps, completed_reps)
-		 VALUES (?, ?, ?, 1, 60.0, 5, 5, 5)`,
+		 VALUES (?, ?, ?, 1, 100.0, 5, 5, 5)`,
 		userID, dateStr, exerciseID)
 	if err != nil {
 		t.Fatalf("insert set: %v", err)
 	}
 
-	got, err = svc.GetStartingWeight(ctx, exerciseID, today)
+	// Same periodization (strength → strength): weight carries over unchanged.
+	got, err = svc.GetStartingWeight(ctx, exerciseID, today, workout.PeriodizationStrength)
 	if err != nil {
 		t.Fatalf("GetStartingWeight with history: %v", err)
 	}
-	if got != 60.0 {
-		t.Errorf("with history: want 60.0, got %v", got)
+	if got != 100.0 {
+		t.Errorf("strength → strength: want 100.0, got %v", got)
+	}
+
+	// Cross-periodization (strength 5 reps → hypertrophy 8 reps): Epley conversion
+	// 100 * (1 + 5/30) / (1 + 8/30) ≈ 92.1, rounded to 0.5 = 92.0.
+	got, err = svc.GetStartingWeight(ctx, exerciseID, today, workout.PeriodizationHypertrophy)
+	if err != nil {
+		t.Fatalf("GetStartingWeight cross-periodization: %v", err)
+	}
+	if got != 92.0 {
+		t.Errorf("strength → hypertrophy: want 92.0, got %v", got)
 	}
 
 	// Insert today's session with a different set 1 weight. The starting weight
@@ -643,12 +655,12 @@ func Test_GetStartingWeight(t *testing.T) {
 		t.Fatalf("insert today's sets: %v", err)
 	}
 
-	got, err = svc.GetStartingWeight(ctx, exerciseID, today)
+	got, err = svc.GetStartingWeight(ctx, exerciseID, today, workout.PeriodizationStrength)
 	if err != nil {
 		t.Fatalf("GetStartingWeight ignoring today: %v", err)
 	}
-	if got != 60.0 {
-		t.Errorf("today ignored: want 60.0, got %v", got)
+	if got != 100.0 {
+		t.Errorf("today ignored: want 100.0, got %v", got)
 	}
 }
 
@@ -821,5 +833,88 @@ func Test_BuildProgression(t *testing.T) {
 	target = prog.CurrentSet()
 	if target.WeightKg != 2.5 {
 		t.Errorf("second set weight: want 2.5, got %v", target.WeightKg)
+	}
+}
+
+func Test_BuildProgression_CrossPeriodizationConversion(t *testing.T) {
+	ctx := t.Context()
+	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))
+	db, err := sqlite.NewDatabase(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var userID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		"INSERT INTO users (webauthn_user_id, display_name) VALUES (?, ?) RETURNING id",
+		[]byte("bp-x-user"), "BPX User").Scan(&userID)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
+	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
+
+	_, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO exercises (name, category, description_markdown) VALUES (?, ?, ?)",
+		"Squat", "lower", "desc")
+	if err != nil {
+		t.Fatalf("insert exercise: %v", err)
+	}
+	var exerciseID int
+	err = db.ReadOnly.QueryRowContext(ctx, "SELECT id FROM exercises WHERE name = 'Squat'").Scan(&exerciseID)
+	if err != nil {
+		t.Fatalf("get exercise id: %v", err)
+	}
+
+	// Prior strength session 7 days ago: completed first set 100 kg x 5.
+	prevStr := time.Now().AddDate(0, 0, -7).Format("2006-01-02")
+	_, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO workout_sessions (user_id, workout_date, completed_at, periodization_type)
+		 VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'), 'strength')`,
+		userID, prevStr)
+	if err != nil {
+		t.Fatalf("insert prev session: %v", err)
+	}
+	_, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO exercise_sets (workout_user_id, workout_date, exercise_id, set_number,
+		 weight_kg, min_reps, max_reps, completed_reps)
+		 VALUES (?, ?, ?, 1, 100.0, 5, 5, 5)`,
+		userID, prevStr, exerciseID)
+	if err != nil {
+		t.Fatalf("insert prev set: %v", err)
+	}
+
+	// New hypertrophy session today.
+	todayStr := time.Now().Format("2006-01-02")
+	_, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO workout_sessions (user_id, workout_date, started_at, periodization_type)
+		 VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'), 'hypertrophy')`,
+		userID, todayStr)
+	if err != nil {
+		t.Fatalf("insert today session: %v", err)
+	}
+	_, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id) VALUES (?, ?, ?)",
+		userID, todayStr, exerciseID)
+	if err != nil {
+		t.Fatalf("insert workout_exercise: %v", err)
+	}
+
+	svc := workout.NewService(db, logger, "")
+	date, _ := time.Parse("2006-01-02", todayStr)
+
+	prog, err := svc.BuildProgression(ctx, date, exerciseID)
+	if err != nil {
+		t.Fatalf("BuildProgression: %v", err)
+	}
+	target := prog.CurrentSet()
+	// Strength 100kg x5 → Hypertrophy 8 reps via Epley:
+	// 100 * (1 + 5/30) / (1 + 8/30) ≈ 92.105, rounded to 0.5 = 92.0.
+	if target.WeightKg != 92.0 {
+		t.Errorf("first set weight: want 92.0, got %v", target.WeightKg)
+	}
+	if target.TargetReps != 8 {
+		t.Errorf("first set reps: want 8, got %v", target.TargetReps)
 	}
 }


### PR DESCRIPTION
When a session's periodization differs from the previous one, convert
the carried-over weight via Epley 1RM equivalence so the relative
intensity stays consistent (e.g. 100 kg x 5 strength → ~92 kg x 8
hypertrophy) instead of reusing the raw last-completed weight.

https://claude.ai/code/session_01LHErt9kqxjY64fhjae5zUT