### PR TITLE
Replace weighted set signal radios with named submit buttons

### DIFF
--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -228,19 +228,10 @@ func (app *application) recordWeightedSetCompletion(
 
 	signal := workout.Signal(r.PostForm.Get("signal"))
 
-	var reps int
-	if signal == workout.SignalTooHeavy {
-		reps, err = strconv.Atoi(r.PostForm.Get("reps"))
-		if err != nil {
-			app.serverError(w, r, fmt.Errorf("parse reps: %w", err))
-			return false
-		}
-	} else {
-		reps, err = strconv.Atoi(r.PostForm.Get("target_reps"))
-		if err != nil {
-			app.serverError(w, r, fmt.Errorf("parse target_reps: %w", err))
-			return false
-		}
+	reps, err := strconv.Atoi(r.PostForm.Get("reps"))
+	if err != nil {
+		app.serverError(w, r, fmt.Errorf("parse reps: %w", err))
+		return false
 	}
 
 	err = app.workoutService.RecordSetCompletion(r.Context(), date, exerciseID, setIndex, signal, weight, reps)

--- a/cmd/web/handler-exerciseset_test.go
+++ b/cmd/web/handler-exerciseset_test.go
@@ -130,10 +130,12 @@ func Test_application_exerciseSet(t *testing.T) {
 		}
 	}
 
-	// Find the signal form for completing a weighted set
-	setForm := doc.Find("form.signal-form").First()
+	// Find the form for completing a weighted set (has signal submit buttons).
+	setForm := doc.Find("form").FilterFunction(func(_ int, s *goquery.Selection) bool {
+		return s.Find("button[name='signal']").Length() > 0
+	}).First()
 	if setForm.Length() == 0 {
-		t.Fatalf("Expected to find signal-form for active set")
+		t.Fatalf("Expected to find set form with signal buttons for active set")
 	}
 
 	setAction, exists := setForm.Attr("action")
@@ -142,9 +144,9 @@ func Test_application_exerciseSet(t *testing.T) {
 	}
 
 	if doc, err = client.PostForm(ctx, doc, setAction, map[string]string{
-		"weight":      "20.5",
-		"signal":      "on_target",
-		"target_reps": "5",
+		"weight": "20.5",
+		"signal": "on_target",
+		"reps":   "5",
 	}); err != nil {
 		t.Fatalf("Failed to submit signal form: %v", err)
 	}
@@ -201,8 +203,10 @@ func Test_application_exerciseSet(t *testing.T) {
 		t.Fatalf("Failed to load edit page: %v", err)
 	}
 
-	// Find the signal form for the edit page
-	editSignalForm := doc.Find("form.signal-form").First()
+	// Find the form for the edit page (has signal submit buttons).
+	editSignalForm := doc.Find("form").FilterFunction(func(_ int, s *goquery.Selection) bool {
+		return s.Find("button[name='signal']").Length() > 0
+	}).First()
 	if editSignalForm.Length() == 0 {
 		t.Fatalf("Edit signal form not found")
 	}
@@ -225,9 +229,9 @@ func Test_application_exerciseSet(t *testing.T) {
 
 	// Update the completed set with new weight and signal
 	if doc, err = client.PostForm(ctx, doc, editAction, map[string]string{
-		"weight":      strconv.FormatFloat(newWeight, 'f', 1, 64),
-		"signal":      "on_target",
-		"target_reps": "12",
+		"weight": strconv.FormatFloat(newWeight, 'f', 1, 64),
+		"signal": "on_target",
+		"reps":   "12",
 	}); err != nil {
 		t.Fatalf("Failed to submit set update form: %v", err)
 	}

--- a/cmd/web/playwright_test.go
+++ b/cmd/web/playwright_test.go
@@ -204,23 +204,18 @@ func Test_playwright_smoketest(t *testing.T) {
 			break
 		}
 
-		// The weighted radios are visually hidden; the label wrapping each one is what the user
-		// actually sees and clicks. Count on the radio locator is enough to detect whether this
-		// is a weighted exercise, then we click the associated label to trigger the JS-initiated
-		// form submission.
-		couldDoMoreRadio := currentSet.GetByRole("radio",
+		// Weighted exercises show three named signal submit buttons; bodyweight exercises show
+		// a single "Complete set" submit button and require filling the reps input first.
+		couldDoMoreBtn := currentSet.GetByRole("button",
 			playwright.LocatorGetByRoleOptions{Name: "Could have done more reps"})
-		var radioCount int
-		if radioCount, err = couldDoMoreRadio.Count(); err != nil {
-			t.Fatalf("count weighted signal radios: %v", err)
+		var btnCount int
+		if btnCount, err = couldDoMoreBtn.Count(); err != nil {
+			t.Fatalf("count weighted signal buttons: %v", err)
 		}
 
-		if radioCount > 0 {
-			couldDoMoreLabel := currentSet.GetByText("Could do more", playwright.LocatorGetByTextOptions{
-				Exact: new(true),
-			})
-			if err = couldDoMoreLabel.Click(); err != nil {
-				t.Fatalf("click Could do more: %v", err)
+		if btnCount > 0 {
+			if err = couldDoMoreBtn.Click(); err != nil {
+				t.Fatalf("click Could have done more reps: %v", err)
 			}
 		} else {
 			repsInput := currentSet.GetByRole("textbox", playwright.LocatorGetByRoleOptions{Name: "Reps"})

--- a/ui/templates/pages/exerciseset/exerciseset.gohtml
+++ b/ui/templates/pages/exerciseset/exerciseset.gohtml
@@ -40,28 +40,10 @@
 
         <script {{ nonce }}>
           document.addEventListener("DOMContentLoaded", function () {
-            document.querySelectorAll('.signal-form').forEach(function (form) {
-              form.querySelectorAll('input[name="signal"]').forEach(function (radio) {
-                radio.addEventListener('change', function () {
-                  if (this.value !== 'too_heavy') {
-                    form.submit()
-                  } else {
-                    var repsInput = form.querySelector('.reps-input')
-                    if (repsInput) {
-                      setTimeout(function () { repsInput.focus() }, 50)
-                    }
-                  }
-                })
-              })
-            })
             const form = document.getElementById(`form-{{ $.EditingIndex }}`)
             if (form) {
               const repsInput = form.querySelector('.reps-input')
               if (repsInput) {
-                // Enable the reps input
-                repsInput.disabled = false
-
-                // Focus and select the text
                 setTimeout(() => {
                   repsInput.focus()
                   repsInput.select()

--- a/ui/templates/pages/exerciseset/sets-container.gohtml
+++ b/ui/templates/pages/exerciseset/sets-container.gohtml
@@ -173,13 +173,6 @@
                         }
                     }
 
-                    .signal-radio {
-                        position: absolute;
-                        opacity: 0;
-                        width: 0;
-                        height: 0;
-                    }
-
                     .signal-btn {
                         display: inline-flex;
                         align-items: center;
@@ -194,7 +187,7 @@
                         min-height: 3rem;
                         transition: background-color 0.2s ease, box-shadow 0.2s ease;
 
-                        &:focus-within {
+                        &:focus-visible {
                             outline: 3px solid var(--color-border-focus);
                             outline-offset: 2px;
                         }
@@ -204,7 +197,7 @@
                             color: var(--red-8);
                             border-color: var(--red-3);
                             &:hover { background: var(--red-2); }
-                            &:has(input:checked) { background: var(--red-2); box-shadow: 0 0 0 3px var(--red-5); }
+                            &:active { background: var(--red-2); box-shadow: 0 0 0 3px var(--red-5); }
                         }
 
                         &.on-target-btn {
@@ -212,7 +205,7 @@
                             color: var(--color-success);
                             border-color: var(--lime-4);
                             &:hover { background: var(--lime-2); }
-                            &:has(input:checked) { background: var(--lime-2); box-shadow: 0 0 0 3px var(--lime-5); }
+                            &:active { background: var(--lime-2); box-shadow: 0 0 0 3px var(--lime-5); }
                         }
 
                         &.too-light-btn {
@@ -220,19 +213,8 @@
                             color: var(--color-info);
                             border-color: var(--sky-3);
                             &:hover { background: var(--sky-2); }
-                            &:has(input:checked) { background: var(--sky-2); box-shadow: 0 0 0 3px var(--sky-5); }
+                            &:active { background: var(--sky-2); box-shadow: 0 0 0 3px var(--sky-5); }
                         }
-                    }
-
-                    .reps-section {
-                        display: none;
-                        gap: var(--size-3);
-                        align-items: end;
-                        flex-wrap: wrap;
-                    }
-
-                    .signal-form:has(input[name="signal"][value="too_heavy"]:checked) .reps-section {
-                        display: flex;
                     }
 
                     .submit-button {
@@ -313,9 +295,8 @@
                         <form method="post"
                               action="/workouts/{{ $.Date.Format "2006-01-02" }}/exercises/{{ $.ExerciseSet.Exercise.ID }}/sets/{{ $index }}/update"
                               id="form-{{ $index }}"
-                              class="set-form signal-form"
+                              class="set-form"
                               aria-label="Complete current set">
-                            <input type="hidden" name="target_reps" value="{{ $.CurrentSetTarget.TargetReps }}">
                             <div class="input-field">
                                 <label for="weight-{{ $index }}">Weight (kg)</label>
                                 <input
@@ -330,42 +311,34 @@
                                 >
                                 <div id="weight-help-{{ $index }}" class="sr-only">Enter weight in kilograms</div>
                             </div>
+                            <div class="input-field">
+                                <label for="reps-{{ $index }}">Actual reps</label>
+                                <input
+                                        id="reps-{{ $index }}"
+                                        inputmode="numeric"
+                                        pattern="[0-9]*"
+                                        name="reps"
+                                        value="{{ $.CurrentSetTarget.TargetReps }}"
+                                        required
+                                        class="reps-input"
+                                        aria-describedby="reps-help-{{ $index }}"
+                                >
+                                <div id="reps-help-{{ $index }}" class="sr-only">Enter actual repetitions completed</div>
+                            </div>
                             <fieldset class="signal-group">
                                 <legend>Did you reach {{ $.CurrentSetTarget.TargetReps }} reps?</legend>
                                 <div class="signal-buttons">
-                                    <label class="signal-btn too-heavy-btn">
-                                        <input type="radio" name="signal" value="too_heavy" class="signal-radio"
-                                               aria-label="No, I failed to reach target reps">
-                                        No
-                                    </label>
-                                    <label class="signal-btn on-target-btn">
-                                        <input type="radio" name="signal" value="on_target" class="signal-radio"
-                                               aria-label="Barely reached target reps">
-                                        Barely
-                                    </label>
-                                    <label class="signal-btn too-light-btn">
-                                        <input type="radio" name="signal" value="too_light" class="signal-radio"
-                                               aria-label="Could have done more reps">
-                                        Could do more
-                                    </label>
+                                    <button type="submit" name="signal" value="too_heavy"
+                                            class="signal-btn too-heavy-btn"
+                                            aria-label="No, I failed to reach target reps">No</button>
+                                    <button type="submit" name="signal" value="on_target"
+                                            class="signal-btn on-target-btn"
+                                            aria-label="Barely reached target reps">Barely</button>
+                                    <button type="submit" name="signal" value="too_light"
+                                            class="signal-btn too-light-btn"
+                                            aria-label="Could have done more reps">Could do more</button>
                                 </div>
                             </fieldset>
-                            <div class="reps-section">
-                                <div class="input-field">
-                                    <label for="reps-{{ $index }}">Actual reps</label>
-                                    <input
-                                            id="reps-{{ $index }}"
-                                            inputmode="numeric"
-                                            pattern="[0-9]*"
-                                            name="reps"
-                                            required
-                                            class="reps-input"
-                                            aria-describedby="reps-help-{{ $index }}"
-                                    >
-                                    <div id="reps-help-{{ $index }}" class="sr-only">Enter actual repetitions completed</div>
-                                </div>
-                                <button type="submit" class="submit-button" aria-label="Submit set">Submit</button>
-                            </div>
                         </form>
                     {{ else }}
                         <form method="post"


### PR DESCRIPTION
Each signal option (too_heavy, on_target, too_light) is now a
<button type="submit" name="signal" value="..."> so the form works
without JavaScript. The reps input is always visible and pre-filled
with the target, so users can adjust before clicking a signal button.
The handler now reads reps from the form field in all cases, removing
the target_reps hidden field and its fallback branch.

https://claude.ai/code/session_01GfpitJnKhz6h2gtzn6s2sZ