### PR TITLE
Allow starting workouts early from the home page.

### DIFF
--- a/cmd/web/handler-home.go
+++ b/cmd/web/handler-home.go
@@ -201,6 +201,11 @@ func calculateWorkoutAction(status string, isToday bool) *workoutAction {
 			StartWorkout: false,
 			Label:        "View Details",
 		}
+	case statusUpcoming:
+		return &workoutAction{
+			StartWorkout: true,
+			Label:        "Start Early",
+		}
 	case statusPastIncomplete:
 		return &workoutAction{
 			StartWorkout: false,


### PR DESCRIPTION
Upcoming scheduled workouts now show a "Start Early" button, using the
same POST /workouts/{date}/start endpoint. Previously the button only
appeared for today's workout.

https://claude.ai/code/session_01BpoEpMy5wsEJaTUPJ4VAuY