### PR TITLE
Force weekly workout regeneration on preference save when no workout started

### DIFF
--- a/cmd/web/handler-preferences.go
+++ b/cmd/web/handler-preferences.go
@@ -115,6 +115,11 @@ func (app *application) preferencesPOST(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if err := app.workoutService.RegenerateWeeklyPlanIfUnstarted(r.Context()); err != nil {
+		app.serverError(w, r, fmt.Errorf("regenerate weekly plan: %w", err))
+		return
+	}
+
 	redirect(w, r, "/")
 }
 

--- a/cmd/web/handler-preferences.go
+++ b/cmd/web/handler-preferences.go
@@ -116,8 +116,10 @@ func (app *application) preferencesPOST(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := app.workoutService.RegenerateWeeklyPlanIfUnstarted(r.Context()); err != nil {
-		app.serverError(w, r, fmt.Errorf("regenerate weekly plan: %w", err))
-		return
+		// Preferences are already saved; regeneration failure is not fatal because
+		// ResolveWeeklySchedule on the home page will regenerate the plan automatically.
+		app.logger.LogAttrs(r.Context(), slog.LevelWarn, "regenerate weekly plan after preference save",
+			slog.Any("error", err))
 	}
 
 	redirect(w, r, "/")

--- a/internal/workout/repository-sessions.go
+++ b/internal/workout/repository-sessions.go
@@ -603,6 +603,20 @@ func (r *sqliteSessionRepository) scanExerciseSetWithDate(
 	return workoutDateStr, set, warmupCompletedAtStr, nil
 }
 
+// DeleteWeek removes all sessions for the 7-day window [monday, monday+6].
+// The ON DELETE CASCADE foreign keys clear related workout_exercise and exercise_sets rows.
+func (r *sqliteSessionRepository) DeleteWeek(ctx context.Context, monday time.Time) error {
+	userID := contexthelpers.AuthenticatedUserID(ctx)
+	sunday := monday.AddDate(0, 0, 6) //nolint:mnd // 6 days after Monday is Sunday.
+	if _, err := r.db.ReadWrite.ExecContext(ctx, `
+		DELETE FROM workout_sessions
+		WHERE user_id = ? AND workout_date >= ? AND workout_date <= ?`,
+		userID, formatDate(monday), formatDate(sunday)); err != nil {
+		return fmt.Errorf("delete week sessions: %w", err)
+	}
+	return nil
+}
+
 // CountCompleted returns the number of completed sessions for the authenticated user.
 func (r *sqliteSessionRepository) CountCompleted(ctx context.Context) (int, error) {
 	userID := contexthelpers.AuthenticatedUserID(ctx)

--- a/internal/workout/repository.go
+++ b/internal/workout/repository.go
@@ -79,6 +79,8 @@ type sessionRepository interface {
 	CountCompleted(ctx context.Context) (int, error)
 	// CreateBatch creates multiple sessions atomically in a single transaction.
 	CreateBatch(ctx context.Context, sessions []sessionAggregate) error
+	// DeleteWeek removes all sessions for the 7-day window starting on monday.
+	DeleteWeek(ctx context.Context, monday time.Time) error
 }
 
 // exerciseRepository handles exercises and sets.

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -50,6 +50,33 @@ func (s *Service) SaveUserPreferences(ctx context.Context, prefs Preferences) er
 	return nil
 }
 
+// RegenerateWeeklyPlanIfUnstarted replaces the current week's generated plan with one
+// that reflects the latest preferences, but only when no session has been started yet.
+// If any workout this week has a non-zero StartedAt the existing plan is left intact.
+func (s *Service) RegenerateWeeklyPlanIfUnstarted(ctx context.Context) error {
+	monday := mondayOf(time.Now())
+	sunday := monday.AddDate(0, 0, 6) //nolint:mnd // 6 days after Monday is Sunday.
+
+	existing, err := s.repo.sessions.List(ctx, monday)
+	if err != nil {
+		return fmt.Errorf("list sessions for week: %w", err)
+	}
+
+	for _, sess := range existing {
+		if !sess.Date.After(sunday) && !sess.StartedAt.IsZero() {
+			return nil
+		}
+	}
+
+	if err = s.repo.sessions.DeleteWeek(ctx, monday); err != nil {
+		return fmt.Errorf("delete current week: %w", err)
+	}
+	if err = s.generateWeeklyPlan(ctx, monday); err != nil {
+		return fmt.Errorf("generate weekly plan: %w", err)
+	}
+	return nil
+}
+
 // ResolveWeeklySchedule retrieves the workout schedule for the current week.
 // If no sessions exist for the week, it generates all scheduled days at once using
 // the weekly planner and persists them in a single transaction.

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -53,6 +53,11 @@ func (s *Service) SaveUserPreferences(ctx context.Context, prefs Preferences) er
 // RegenerateWeeklyPlanIfUnstarted replaces the current week's generated plan with one
 // that reflects the latest preferences, but only when no session has been started yet.
 // If any workout this week has a non-zero StartedAt the existing plan is left intact.
+//
+// The delete and generate steps are not wrapped in a single transaction. If the process
+// fails between the two, the week is left with no sessions. This is self-healing: the
+// next call to ResolveWeeklySchedule (e.g. on the home page redirect) detects zero
+// sessions and regenerates automatically.
 func (s *Service) RegenerateWeeklyPlanIfUnstarted(ctx context.Context) error {
 	monday := mondayOf(time.Now())
 	sunday := monday.AddDate(0, 0, 6) //nolint:mnd // 6 days after Monday is Sunday.
@@ -62,6 +67,8 @@ func (s *Service) RegenerateWeeklyPlanIfUnstarted(ctx context.Context) error {
 		return fmt.Errorf("list sessions for week: %w", err)
 	}
 
+	// List returns sessions from monday onwards (possibly spanning future weeks);
+	// only sessions within this week are relevant for the started check.
 	for _, sess := range existing {
 		if !sess.Date.After(sunday) && !sess.StartedAt.IsZero() {
 			return nil

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -111,6 +111,26 @@ func Test_GetSession_ReturnsErrNotFoundForUnplannedDate(t *testing.T) {
 	}
 }
 
+func Test_RegenerateWeeklyPlanIfUnstarted_RegeneratesFromEmptyWeek(t *testing.T) {
+	ctx, svc := setupTestService(t) // Mon, Wed, Fri at 60 min — no sessions created yet
+
+	// Call directly without seeding via ResolveWeeklySchedule first.
+	if err := svc.RegenerateWeeklyPlanIfUnstarted(ctx); err != nil {
+		t.Fatalf("RegenerateWeeklyPlanIfUnstarted on empty week: %v", err)
+	}
+
+	sessions, err := svc.ResolveWeeklySchedule(ctx)
+	if err != nil {
+		t.Fatalf("ResolveWeeklySchedule after empty-week regenerate: %v", err)
+	}
+	// Mon=0, Wed=2, Fri=4 must have exercises.
+	for _, i := range []int{0, 2, 4} {
+		if len(sessions[i].ExerciseSets) == 0 {
+			t.Errorf("sessions[%d] (%s) must have exercise sets", i, sessions[i].Date.Weekday())
+		}
+	}
+}
+
 func Test_RegenerateWeeklyPlanIfUnstarted_RegeneratesWhenNoWorkoutStarted(t *testing.T) {
 	ctx, svc := setupTestService(t) // Mon, Wed, Fri at 60 min
 

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -111,6 +111,87 @@ func Test_GetSession_ReturnsErrNotFoundForUnplannedDate(t *testing.T) {
 	}
 }
 
+func Test_RegenerateWeeklyPlanIfUnstarted_RegeneratesWhenNoWorkoutStarted(t *testing.T) {
+	ctx, svc := setupTestService(t) // Mon, Wed, Fri at 60 min
+
+	// Generate the initial plan.
+	if _, err := svc.ResolveWeeklySchedule(ctx); err != nil {
+		t.Fatalf("ResolveWeeklySchedule: %v", err)
+	}
+
+	// Change to Tue, Thu, Sat at 45 min.
+	if err := svc.SaveUserPreferences(ctx, workout.Preferences{ //nolint:exhaustruct // Rest days intentionally omitted.
+		TuesdayMinutes:  45,
+		ThursdayMinutes: 45,
+		SaturdayMinutes: 45,
+	}); err != nil {
+		t.Fatalf("save preferences: %v", err)
+	}
+
+	if err := svc.RegenerateWeeklyPlanIfUnstarted(ctx); err != nil {
+		t.Fatalf("RegenerateWeeklyPlanIfUnstarted: %v", err)
+	}
+
+	sessions, err := svc.ResolveWeeklySchedule(ctx)
+	if err != nil {
+		t.Fatalf("ResolveWeeklySchedule after regenerate: %v", err)
+	}
+
+	// Tue=1, Thu=3, Sat=5 must have exercises; Mon=0, Wed=2, Fri=4, Sun=6 must be rest.
+	for _, i := range []int{1, 3, 5} {
+		if len(sessions[i].ExerciseSets) == 0 {
+			t.Errorf("sessions[%d] (%s) must have exercise sets after preference change", i, sessions[i].Date.Weekday())
+		}
+	}
+	for _, i := range []int{0, 2, 4, 6} {
+		if len(sessions[i].ExerciseSets) != 0 {
+			t.Errorf("sessions[%d] (%s) must be a rest day after preference change", i, sessions[i].Date.Weekday())
+		}
+	}
+}
+
+func Test_RegenerateWeeklyPlanIfUnstarted_SkipsRegenerateWhenWorkoutStarted(t *testing.T) {
+	ctx, svc := setupTestService(t) // Mon, Wed, Fri at 60 min
+
+	sessions, err := svc.ResolveWeeklySchedule(ctx)
+	if err != nil {
+		t.Fatalf("ResolveWeeklySchedule: %v", err)
+	}
+
+	// Start the first scheduled workout (Monday, index 0).
+	if err = svc.StartSession(ctx, sessions[0].Date); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// Change preferences to Tue, Thu, Sat.
+	if err = svc.SaveUserPreferences(ctx, workout.Preferences{ //nolint:exhaustruct // Rest days intentionally omitted.
+		TuesdayMinutes:  45,
+		ThursdayMinutes: 45,
+		SaturdayMinutes: 45,
+	}); err != nil {
+		t.Fatalf("save preferences: %v", err)
+	}
+
+	if err = svc.RegenerateWeeklyPlanIfUnstarted(ctx); err != nil {
+		t.Fatalf("RegenerateWeeklyPlanIfUnstarted: %v", err)
+	}
+
+	sessions2, err := svc.ResolveWeeklySchedule(ctx)
+	if err != nil {
+		t.Fatalf("ResolveWeeklySchedule after skip: %v", err)
+	}
+
+	// Monday (index 0) must still have exercises — the original plan was kept.
+	if len(sessions2[0].ExerciseSets) == 0 {
+		t.Error("sessions2[0] (Monday) must still have exercise sets; workout was already started")
+	}
+
+	// Tuesday must still be a rest day — the new preferences were not applied.
+	if len(sessions2[1].ExerciseSets) != 0 {
+		t.Error("sessions2[1] (Tuesday) must remain a rest day; new preferences must not be applied")
+	}
+}
+
 func extractExerciseIDs(session workout.Session) []int {
 	ids := make([]int, len(session.ExerciseSets))
 	for i, es := range session.ExerciseSets {


### PR DESCRIPTION
When a user saves their preferences, regenerate the current week's plan
immediately so the new schedule takes effect without requiring a page
reload. Regeneration is skipped if any session this week has already
been started, preserving in-progress work.

https://claude.ai/code/session_01CrqPidEg4NGp16Zpqw4d3H