### PR TITLE
bust-bfcache

### DIFF
--- a/cmd/web/handler-preferences.go
+++ b/cmd/web/handler-preferences.go
@@ -146,7 +146,8 @@ func (app *application) deleteUserPOST(w http.ResponseWriter, r *http.Request) {
 
 // clearSiteData to ensure you can't navigate backwards to sensitive content after logging out.
 func clearSiteData(w http.ResponseWriter) {
-	w.Header().Set("Clear-Site-Data", "\"cache\", \"cookies\", \"storage\", \"executionContexts\", \"prefetchCache\", \"prerenderCache\"")
+	w.Header().Set("Clear-Site-Data",
+		"\"cache\", \"cookies\", \"storage\", \"executionContexts\", \"prefetchCache\", \"prerenderCache\"")
 }
 
 func (app *application) exportUserDataGET(w http.ResponseWriter, r *http.Request) {

--- a/cmd/web/handler-preferences.go
+++ b/cmd/web/handler-preferences.go
@@ -135,12 +135,18 @@ func (app *application) deleteUserPOST(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Log the user out by clearing the session and redirect home.
+	clearSiteData(w)
 	if err := app.webAuthnHandler.Logout(ctx); err != nil {
 		app.serverError(w, r, fmt.Errorf("logout after user deletion: %w", err))
 		return
 	}
 
 	redirect(w, r, "/")
+}
+
+// clearSiteData to ensure you can't navigate backwards to sensitive content after logging out.
+func clearSiteData(w http.ResponseWriter) {
+	w.Header().Set("Clear-Site-Data", "\"cache\", \"cookies\", \"storage\", \"executionContexts\", \"prefetchCache\", \"prerenderCache\"")
 }
 
 func (app *application) exportUserDataGET(w http.ResponseWriter, r *http.Request) {

--- a/cmd/web/handlers-webauthn.go
+++ b/cmd/web/handlers-webauthn.go
@@ -63,6 +63,7 @@ func (app *application) finishLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *application) logout(w http.ResponseWriter, r *http.Request) {
+	clearSiteData(w)
 	if err := app.webAuthnHandler.Logout(r.Context()); err != nil {
 		app.serverError(w, r, err)
 		return

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -83,6 +83,7 @@ report-uri /api/reports; report-to reports;`, cspNonce, cspNonce)
 	})
 }
 
+// cacheForever for static assets ensures they are cached indefinitely.
 func cacheForever(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
@@ -91,10 +92,20 @@ func cacheForever(next http.Handler) http.Handler {
 	})
 }
 
+// noCache ensures authenticated requests force revalidation.
 func noCache(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Cache-Control", "private, max-age=0, must-revalidate")
+		w.Header().Set("Vary", "Vary: Cookie, Accept")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// noStore is used for authentication routes to prevent caching sensitive data anywhere.
+func noStore(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store, max-age=0, must-revalidate")
+		w.Header().Set("Vary", "Vary: Cookie, Accept")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -76,6 +76,8 @@ report-uri /api/reports; report-to reports;`, cspNonce, cspNonce)
 		w.Header().Set("X-XSS-Protection", "0")
 		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
 		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+		// Prevent unload handlers from disabling bfcache.
+		w.Header().Set("Permissions-Policy", "unload=()")
 
 		r = contexthelpers.SetCSPNonce(r, cspNonce)
 

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -287,10 +287,10 @@ func setInvalidationCookieOnPost(next http.Handler) http.Handler {
 				Name:     "inv_bfcache",
 				Value:    rand.Text(),
 				Path:     "/",
-				MaxAge:   60, //nolint:mnd // One shot cookie cleared client side.
+				MaxAge:   60, //nolint:mnd // Lives long enough for a back-button after a POST to detect staleness.
 				SameSite: http.SameSiteLaxMode,
 				Secure:   true,
-				HttpOnly: false, // We need this client side to trigger busting of bfcache in pageshow handler.
+				HttpOnly: false, // Read client-side in the pageshow handler to compare against the rendered snapshot.
 			})
 		}
 		next.ServeHTTP(w, r)

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -278,3 +278,21 @@ func (app *application) maintenanceMode(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// setInvalidationCookieOnPost busts bfcache by setting a cookie.
+func setInvalidationCookieOnPost(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			http.SetCookie(w, &http.Cookie{
+				Name:     "inv_bfcache",
+				Value:    rand.Text(),
+				Path:     "/",
+				MaxAge:   60,
+				SameSite: http.SameSiteLaxMode,
+				Secure:   true,
+				HttpOnly: false, // We need this client side to trigger busting of bfcache in pageshow handler.
+			})
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -287,7 +287,7 @@ func setInvalidationCookieOnPost(next http.Handler) http.Handler {
 				Name:     "inv_bfcache",
 				Value:    rand.Text(),
 				Path:     "/",
-				MaxAge:   60,
+				MaxAge:   60, //nolint:mnd // One shot cookie cleared client side.
 				SameSite: http.SameSiteLaxMode,
 				Secure:   true,
 				HttpOnly: false, // We need this client side to trigger busting of bfcache in pageshow handler.

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -98,7 +98,7 @@ func cacheForever(next http.Handler) http.Handler {
 func noCache(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "private, max-age=0, must-revalidate")
-		w.Header().Set("Vary", "Vary: Cookie, Accept")
+		w.Header().Set("Vary", "Cookie, Accept")
 		next.ServeHTTP(w, r)
 	})
 }
@@ -107,7 +107,7 @@ func noCache(next http.Handler) http.Handler {
 func noStore(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store, max-age=0, must-revalidate")
-		w.Header().Set("Vary", "Vary: Cookie, Accept")
+		w.Header().Set("Vary", "Cookie, Accept")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -19,9 +19,15 @@ func (app *application) routes() (*http.ServeMux, error) {
 		noAuth = func(next http.Handler) http.Handler {
 			return app.recoverPanic(withoutMaintenanceMode(next))
 		}
+		sessionShared = func(next http.Handler) http.Handler {
+			return app.sessionManager.LoadAndSave(
+				app.webAuthnHandler.AuthenticateMiddleware(shared(next)))
+		}
 		session = func(next http.Handler) http.Handler {
-			return app.recoverPanic(noCache(app.sessionManager.LoadAndSave(
-				app.webAuthnHandler.AuthenticateMiddleware(shared(next)))))
+			return app.recoverPanic(noCache(sessionShared(next)))
+		}
+		noStoreSession = func(next http.Handler) http.Handler {
+			return app.recoverPanic(noStore(sessionShared(next)))
 		}
 		mustSession = func(next http.Handler) http.Handler {
 			return session(app.mustAuthenticate(next))
@@ -62,11 +68,12 @@ func (app *application) routes() (*http.ServeMux, error) {
 	mux.Handle("GET /preferences/export-data", mustSession(http.HandlerFunc(app.exportUserDataGET)))
 	mux.Handle("POST /preferences/delete-user", mustSession(http.HandlerFunc(app.deleteUserPOST)))
 
-	mux.Handle("POST /api/registration/start", session(http.HandlerFunc(app.beginRegistration)))
-	mux.Handle("POST /api/registration/finish", session(http.HandlerFunc(app.finishRegistration)))
-	mux.Handle("POST /api/login/start", session(http.HandlerFunc(app.beginLogin)))
-	mux.Handle("POST /api/login/finish", session(http.HandlerFunc(app.finishLogin)))
-	mux.Handle("POST /api/logout", session(http.HandlerFunc(app.logout)))
+	mux.Handle("POST /api/registration/start", noStoreSession(http.HandlerFunc(app.beginRegistration)))
+	mux.Handle("POST /api/registration/finish", noStoreSession(http.HandlerFunc(app.finishRegistration)))
+	mux.Handle("POST /api/login/start", noStoreSession(http.HandlerFunc(app.beginLogin)))
+	mux.Handle("POST /api/login/finish", noStoreSession(http.HandlerFunc(app.finishLogin)))
+	mux.Handle("POST /api/logout", noStoreSession(http.HandlerFunc(app.logout)))
+
 	mux.Handle("GET /api/healthy", session(http.HandlerFunc(app.healthy)))
 	mux.Handle("POST /api/reports", noAuth(http.HandlerFunc(app.reportingAPI)))
 	mux.Handle("GET /api/test/timeout", noAuth(http.HandlerFunc(app.testTimeout)))

--- a/cmd/web/routes.go
+++ b/cmd/web/routes.go
@@ -14,7 +14,7 @@ func (app *application) routes() (*http.ServeMux, error) {
 				commonContext(app.timeout(next)))))
 		}
 		shared = func(next http.Handler) http.Handler {
-			return withoutMaintenanceMode(app.maintenanceMode(next))
+			return withoutMaintenanceMode(app.maintenanceMode(setInvalidationCookieOnPost(next)))
 		}
 		noAuth = func(next http.Handler) http.Handler {
 			return app.recoverPanic(withoutMaintenanceMode(next))

--- a/cmd/web/templates.go
+++ b/cmd/web/templates.go
@@ -10,14 +10,20 @@ import (
 )
 
 type BaseTemplateData struct {
-	Authenticated bool
-	IsAdmin       bool
+	Authenticated     bool
+	IsAdmin           bool
+	InvalidationToken string
 }
 
 func newBaseTemplateData(r *http.Request) BaseTemplateData {
+	var token string
+	if c, err := r.Cookie("inv_bfcache"); err == nil {
+		token = c.Value
+	}
 	return BaseTemplateData{
-		Authenticated: contexthelpers.IsAuthenticated(r.Context()),
-		IsAdmin:       contexthelpers.IsAdmin(r.Context()),
+		Authenticated:     contexthelpers.IsAuthenticated(r.Context()),
+		IsAdmin:           contexthelpers.IsAdmin(r.Context()),
+		InvalidationToken: token,
 	}
 }
 

--- a/ui/static/main.js
+++ b/ui/static/main.js
@@ -175,9 +175,16 @@ document.addEventListener('submit', (e) => {
     if (submitButton) submitButton.disabled = true
 })
 
-// Reset submit state after bfcache restore.
 window.addEventListener('pageshow', (event) => {
     if (event.persisted) {
+        // Refetch page if invalidation cookie is present.
+        const m = document.cookie.match(/(?:^|;\s*)inv_bfcache=([^;]+)/);
+        if (m) {
+            document.cookie = 'inv_bfcache=; Path=/; Max-Age=0; SameSite=Lax; Secure';
+            setTimeout(() => navigation.reload(), 300)
+        }
+
+        // Reset submit state after bfcache restore.
         document.querySelectorAll('form.submitting').forEach((form) => {
             form.classList.remove('submitting')
             const submitButton = form.querySelector('button[type=submit]')

--- a/ui/static/main.js
+++ b/ui/static/main.js
@@ -177,10 +177,14 @@ document.addEventListener('submit', (e) => {
 
 window.addEventListener('pageshow', (event) => {
     if (event.persisted) {
-        // Refetch page if invalidation cookie is present.
-        const m = document.cookie.match(/(?:^|;\s*)inv_bfcache=([^;]+)/);
-        if (m) {
-            document.cookie = 'inv_bfcache=; Path=/; Max-Age=0; SameSite=Lax; Secure';
+        // Reload if the invalidation cookie has changed since this page was rendered.
+        // The render-time value is baked into a <meta> tag; a mismatch means a POST
+        // ran while we were in bfcache and our state may be stale.
+        const meta = document.querySelector('meta[name="invalidation-token"]')
+        const rendered = meta ? meta.content : ''
+        const m = document.cookie.match(/(?:^|;\s*)inv_bfcache=([^;]+)/)
+        const current = m ? m[1] : ''
+        if (rendered !== current) {
             setTimeout(() => navigation.reload(), 300)
         }
 

--- a/ui/static/main.js
+++ b/ui/static/main.js
@@ -185,7 +185,11 @@ window.addEventListener('pageshow', (event) => {
         const m = document.cookie.match(/(?:^|;\s*)inv_bfcache=([^;]+)/)
         const current = m ? m[1] : ''
         if (rendered !== current) {
-            navigation.reload()
+            if ('navigation' in window) {
+                navigation.reload()
+            } else {
+                location.reload()
+            }
         }
 
         // Reset submit state after bfcache restore.

--- a/ui/static/main.js
+++ b/ui/static/main.js
@@ -185,7 +185,7 @@ window.addEventListener('pageshow', (event) => {
         const m = document.cookie.match(/(?:^|;\s*)inv_bfcache=([^;]+)/)
         const current = m ? m[1] : ''
         if (rendered !== current) {
-            setTimeout(() => navigation.reload(), 300)
+            navigation.reload()
         }
 
         // Reset submit state after bfcache restore.

--- a/ui/templates/base.gohtml
+++ b/ui/templates/base.gohtml
@@ -7,6 +7,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <meta name="robots" content="noindex,nofollow"/>
+        <meta name="invalidation-token" content="{{ .InvalidationToken }}"/>
         <title>Petra</title>
         <meta name="description" content="Personal trainer in your pocket."/>
         <link rel="stylesheet" {{ nonce }} href="/main.css"/>


### PR DESCRIPTION
Due to the stack navigator in main.js doing traverseTo after form submissions, the bfcache might show stale content. These changes introduce a cache invalidation approach based on a cookie consumed in the pageshow handler. We also align cache bfcache related HTTP headers with best practices.