### PR TITLE
fix flaky test: harden e2e tests against midnight crossings

### DIFF
--- a/cmd/web/handler-exercise-info_test.go
+++ b/cmd/web/handler-exercise-info_test.go
@@ -25,15 +25,23 @@ func Test_application_exerciseInfo(t *testing.T) {
 
 	client := server.Client()
 
+	// Capture testStart once and reuse it for both the scheduled weekday and the
+	// "today" URL across all subtests so a midnight crossing during the run
+	// cannot desync the two. Schedule the next weekday too so today stays a
+	// workout day on either side of the boundary.
+	testStart := time.Now()
+	today := testStart.Format("2006-01-02")
+
 	// First register to access pages
 	t.Run("Setup", func(t *testing.T) {
 		if _, err = client.Register(ctx); err != nil {
 			t.Fatalf("Failed to register: %v", err)
 		}
 
-		// Set workout preferences (enable today's weekday).
+		// Set workout preferences (enable today's weekday + the next).
 		formData := map[string]string{
-			time.Now().Weekday().String(): "60",
+			testStart.Weekday().String():                  "60",
+			testStart.AddDate(0, 0, 1).Weekday().String(): "60",
 		}
 		if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 			t.Fatalf("Failed to get preferences: %v", err)
@@ -43,7 +51,6 @@ func Test_application_exerciseInfo(t *testing.T) {
 		}
 
 		// Start a workout for today
-		today := time.Now().Format("2006-01-02")
 		if doc, err = client.GetDoc(ctx, "/"); err != nil {
 			t.Fatalf("Failed to get home page: %v", err)
 		}
@@ -56,7 +63,6 @@ func Test_application_exerciseInfo(t *testing.T) {
 
 	// Test viewing exercise info as a regular user
 	t.Run("View exercise info as regular user", func(t *testing.T) {
-		today := time.Now().Format("2006-01-02")
 		// First view the workout to find an exercise
 		if doc, err = client.GetDoc(ctx, "/workouts/"+today); err != nil {
 			t.Fatalf("Failed to get workout page: %v", err)
@@ -111,7 +117,6 @@ func Test_application_exerciseInfo(t *testing.T) {
 			t.Fatalf("Failed to promote user to admin: %v", err)
 		}
 
-		today := time.Now().Format("2006-01-02")
 		// First view the workout to find an exercise
 		if doc, err = client.GetDoc(ctx, "/workouts/"+today); err != nil {
 			t.Fatalf("Failed to get workout page: %v", err)
@@ -157,7 +162,6 @@ func Test_application_exerciseInfo(t *testing.T) {
 
 	// Test error handling with invalid input
 	t.Run("Invalid exercise ID", func(t *testing.T) {
-		today := time.Now().Format("2006-01-02")
 		var resp *http.Response
 		resp, err = client.Get(ctx, "/workouts/"+today+"/exercises/invalid/info")
 		if err != nil {

--- a/cmd/web/handler-exerciseset_test.go
+++ b/cmd/web/handler-exerciseset_test.go
@@ -35,9 +35,12 @@ func Test_application_exerciseSet(t *testing.T) {
 		t.Fatalf("Failed to register: %v", err)
 	}
 
-	// Set workout preferences (enable today's weekday).
+	// Schedule today and the next weekday so a midnight crossing during the test
+	// can't desync the saved weekday from the URL date computed below.
+	testStart := time.Now()
 	formData := map[string]string{
-		time.Now().Weekday().String(): "60",
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
 	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Failed to get preferences: %v", err)
@@ -47,7 +50,7 @@ func Test_application_exerciseSet(t *testing.T) {
 	}
 
 	// Start a workout for today
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	// Find and submit the start workout form
 	if doc, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Failed to submit start workout form: %v", err)
@@ -286,7 +289,11 @@ func Test_application_exerciseSet_swap_preserves_url_and_drops_completed_sets(t 
 		t.Fatalf("Register: %v", err)
 	}
 
-	formData := map[string]string{time.Now().Weekday().String(): "60"}
+	testStart := time.Now()
+	formData := map[string]string{
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
+	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Get preferences: %v", err)
 	}
@@ -294,7 +301,7 @@ func Test_application_exerciseSet_swap_preserves_url_and_drops_completed_sets(t 
 		t.Fatalf("Submit preferences: %v", err)
 	}
 
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if doc, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Start workout: %v", err)
 	}
@@ -408,7 +415,11 @@ func Test_application_workoutSwapExercise_search_filters_by_name(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
-	formData := map[string]string{time.Now().Weekday().String(): "60"}
+	testStart := time.Now()
+	formData := map[string]string{
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
+	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Get preferences: %v", err)
 	}
@@ -416,7 +427,7 @@ func Test_application_workoutSwapExercise_search_filters_by_name(t *testing.T) {
 		t.Fatalf("Submit preferences: %v", err)
 	}
 
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if doc, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Start workout: %v", err)
 	}
@@ -519,9 +530,12 @@ func Test_application_exerciseSet_nonexistent_exercise_returns_custom_404(t *tes
 		t.Fatalf("Failed to register: %v", err)
 	}
 
-	// Set workout preferences (enable today's weekday).
+	// Schedule today and the next weekday so a midnight crossing can't desync
+	// the saved weekday from the URL date.
+	testStart := time.Now()
 	formData := map[string]string{
-		time.Now().Weekday().String(): "60",
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
 	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Failed to get preferences: %v", err)
@@ -531,7 +545,7 @@ func Test_application_exerciseSet_nonexistent_exercise_returns_custom_404(t *tes
 	}
 
 	// Start a workout for today
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if _, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Failed to submit start workout form: %v", err)
 	}
@@ -605,7 +619,11 @@ func Test_application_workoutSwapExercise_sorts_by_similarity(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
-	formData := map[string]string{time.Now().Weekday().String(): "60"}
+	testStart := time.Now()
+	formData := map[string]string{
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
+	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Get preferences: %v", err)
 	}
@@ -613,7 +631,7 @@ func Test_application_workoutSwapExercise_sorts_by_similarity(t *testing.T) {
 		t.Fatalf("Submit preferences: %v", err)
 	}
 
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if doc, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Start workout: %v", err)
 	}
@@ -765,15 +783,21 @@ func Test_application_exerciseSet_assisted_storage(t *testing.T) {
 		t.Fatalf("register: %v", err)
 	}
 
-	// Set preferences and start a workout for today.
-	formData := map[string]string{time.Now().Weekday().String(): "60"}
+	// Set preferences and start a workout for today. Schedule both today and the
+	// next weekday so a midnight crossing during the test still leaves today
+	// scheduled.
+	testStart := time.Now()
+	formData := map[string]string{
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
+	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("get preferences: %v", err)
 	}
 	if doc, err = client.SubmitForm(ctx, doc, "/preferences", formData); err != nil {
 		t.Fatalf("submit preferences: %v", err)
 	}
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if _, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("start workout: %v", err)
 	}

--- a/cmd/web/handler-preferences_test.go
+++ b/cmd/web/handler-preferences_test.go
@@ -149,17 +149,22 @@ func Test_application_exportUserData(t *testing.T) {
 		t.Fatalf("Failed to register: %v", err)
 	}
 
-	// Set up a workout schedule (required before accessing the home page)
+	// Schedule both today and the next weekday so a midnight crossing between setting preferences
+	// and the server's notion of "today" still leaves today scheduled.
+	testStart := time.Now()
 	if doc, err = client.GetDoc(ctx, "/schedule"); err != nil {
 		t.Fatalf("Failed to get schedule page: %v", err)
 	}
-	scheduleForm := map[string]string{time.Now().Weekday().String(): "60"}
+	scheduleForm := map[string]string{
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
+	}
 	if _, err = client.SubmitForm(ctx, doc, "/schedule", scheduleForm); err != nil {
 		t.Fatalf("Failed to submit schedule form: %v", err)
 	}
 
 	// Start a workout to generate some data for the user
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	formData := map[string]string{}
 	if doc, err = client.GetDoc(ctx, "/"); err != nil {
 		t.Fatalf("Failed to get home page: %v", err)
@@ -243,34 +248,19 @@ func Test_application_exportUserData(t *testing.T) {
 		t.Errorf("Expected 1 user in export, got %d", userCount)
 	}
 
-	// Verify there's a single workout session
-	var sessionCount int
-	err = db.QueryRow("SELECT COUNT(*) FROM workout_sessions").Scan(&sessionCount)
-	if err != nil {
-		t.Fatalf("Failed to query workout_sessions table: %v", err)
-	}
-	if sessionCount != 1 {
-		t.Errorf("Expected 1 workout session in export, got %d", sessionCount)
-	}
-
-	// Verify the session has the correct date (today)
-	var sessionDate string
-	err = db.QueryRow("SELECT workout_date FROM workout_sessions LIMIT 1").Scan(&sessionDate)
-	if err != nil {
-		t.Fatalf("Failed to query session date: %v", err)
-	}
-	if sessionDate != today {
-		t.Errorf("Expected session date %s, got %s", today, sessionDate)
-	}
-
-	// Verify the session is started (has started_at timestamp)
+	// Verify the export contains today's session, started. Other days from the
+	// scheduled week are expected to be present too — preferences enabled both
+	// today and tomorrow's weekday to survive a midnight crossing — so we look
+	// up today's row by date rather than asserting an exact session count.
 	var startedAt sql.NullString
-	err = db.QueryRow("SELECT started_at FROM workout_sessions LIMIT 1").Scan(&startedAt)
+	err = db.QueryRow(
+		"SELECT started_at FROM workout_sessions WHERE workout_date = ?", today,
+	).Scan(&startedAt)
 	if err != nil {
-		t.Fatalf("Failed to query session started_at: %v", err)
+		t.Fatalf("Failed to query today's session: %v", err)
 	}
 	if !startedAt.Valid || startedAt.String == "" {
-		t.Error("Expected session to be started (started_at should not be NULL or empty)")
+		t.Error("Expected today's session to be started (started_at should not be NULL or empty)")
 	}
 }
 

--- a/cmd/web/handler-workout_test.go
+++ b/cmd/web/handler-workout_test.go
@@ -31,9 +31,13 @@ func Test_application_addWorkout(t *testing.T) {
 		t.Fatalf("Failed to register: %v", err)
 	}
 
-	// Set workout preferences (enable today's weekday).
+	// Schedule both today and the next weekday so a midnight crossing between setting preferences
+	// and the server's notion of "today" still leaves today scheduled — covering both sides of the
+	// boundary. Reuse testStart for the URL date so it matches the weekday saved into preferences.
+	testStart := time.Now()
 	formData := map[string]string{
-		time.Now().Weekday().String(): "60",
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
 	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Failed to get preferences: %v", err)
@@ -43,7 +47,7 @@ func Test_application_addWorkout(t *testing.T) {
 	}
 
 	// Start a workout for today
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if doc, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Failed to submit start workout form: %v", err)
 	}
@@ -161,7 +165,11 @@ func Test_application_workoutAddExercise_search_filters_by_name(t *testing.T) {
 		t.Fatalf("Register: %v", err)
 	}
 
-	formData := map[string]string{time.Now().Weekday().String(): "60"}
+	testStart := time.Now()
+	formData := map[string]string{
+		testStart.Weekday().String():                  "60",
+		testStart.AddDate(0, 0, 1).Weekday().String(): "60",
+	}
 	if doc, err = client.GetDoc(ctx, "/preferences"); err != nil {
 		t.Fatalf("Get preferences: %v", err)
 	}
@@ -169,7 +177,7 @@ func Test_application_workoutAddExercise_search_filters_by_name(t *testing.T) {
 		t.Fatalf("Submit preferences: %v", err)
 	}
 
-	today := time.Now().Format("2006-01-02")
+	today := testStart.Format("2006-01-02")
 	if _, err = client.SubmitForm(ctx, doc, "/workouts/"+today+"/start", nil); err != nil {
 		t.Fatalf("Start workout: %v", err)
 	}


### PR DESCRIPTION
The previous mondayOf fix corrected the week-boundary calculation for a
single time.Now() instant, but it cannot help when separate time.Now()
calls in the same test land on different sides of midnight: the test
captures today's weekday for /preferences, then captures today's date
for the /workouts/<date>/start URL — if midnight crosses between the two
(in either the test's clock or the server's), the saved weekday and the
URL date desync and StartSession 404s, or duplicate sessions get created
and per-day assertions break.

Apply the playwright_smoketest pattern uniformly to every e2e test that
relies on time.Now() for both prefs and the URL: capture testStart once
and derive both values from it, and schedule both today's and the next
weekday so today stays a scheduled workout day on either side of the
boundary. For Test_application_exportUserData also relax the
session-count assertion to look up today's row by date — with two
weekdays scheduled the export naturally contains more than one session.