### PR TITLE
Use 1kg progression increments below 10kg

### DIFF
--- a/internal/exerciseprogression/conversion.go
+++ b/internal/exerciseprogression/conversion.go
@@ -1,8 +1,9 @@
 package exerciseprogression
 
 // ConvertWeight translates a load chosen for fromReps into an equivalent load
-// for toReps at the same estimated one-rep max, rounded to the nearest 0.5 kg.
-// It uses the Epley formula: 1RM = w * (1 + r/30).
+// for toReps at the same estimated one-rep max, snapped to the nearest
+// realisable load (1kg in the dumbbell range, 0.5kg above). It uses the
+// Epley formula: 1RM = w * (1 + r/30).
 //
 // Returns weight unchanged when fromReps == toReps, or when any input is
 // non-positive. Non-positive weights cover assisted exercises (negative
@@ -14,5 +15,5 @@ func ConvertWeight(weight float64, fromReps, toReps int) float64 {
 	}
 	oneRepMax := weight * (1 + float64(fromReps)/30)
 	converted := oneRepMax / (1 + float64(toReps)/30)
-	return roundToHalf(converted)
+	return snapWeight(converted)
 }

--- a/internal/exerciseprogression/conversion_test.go
+++ b/internal/exerciseprogression/conversion_test.go
@@ -50,11 +50,18 @@ func TestConvertWeight(t *testing.T) {
 			want:     77.0,
 		},
 		{
-			name:     "result is rounded to nearest 0.5 kg",
+			name:     "above threshold result is snapped to 0.5 kg",
 			weight:   42.5,
 			fromReps: 5,
 			toReps:   8,
 			want:     39.0,
+		},
+		{
+			name:     "dumbbell-range hypertrophy to strength snaps to whole kg",
+			weight:   8.0,
+			fromReps: 8,
+			toReps:   5,
+			want:     9.0, // 8 * (1 + 8/30) / (1 + 5/30) ≈ 8.69 → snaps to 9.
 		},
 		{
 			name:     "zero weight returned unchanged",

--- a/internal/exerciseprogression/progression.go
+++ b/internal/exerciseprogression/progression.go
@@ -59,7 +59,6 @@ const (
 	weightIncrementKgLow  = 1.0
 	weightIncrementKgHigh = 2.5
 	weightDecrementFactor = 0.10
-	halfKg                = 0.5
 )
 
 // Progression manages set-to-set weight progression for one exercise execution.
@@ -119,7 +118,7 @@ func TargetReps(t PeriodizationType) int {
 func adjustedWeight(last SetResult) float64 {
 	switch last.Signal {
 	case SignalTooLight:
-		return last.WeightKg + incrementFor(last.WeightKg)
+		return snapWeight(last.WeightKg + incrementFor(last.WeightKg))
 	case SignalTooHeavy:
 		increment := incrementFor(last.WeightKg)
 		decrement := math.Max(increment, math.Abs(last.WeightKg)*weightDecrementFactor)
@@ -142,10 +141,12 @@ func incrementFor(weight float64) float64 {
 }
 
 // snapWeight rounds to the nearest realisable load: 1kg in the dumbbell
-// range, 0.5kg above.
+// range, 0.5kg above. User overrides may sit off-grid, so each adjustment
+// is snapped before being recommended.
 func snapWeight(kg float64) float64 {
 	if math.Abs(kg) < dumbbellThresholdKg {
 		return math.Round(kg)
 	}
+	const halfKg = 0.5
 	return math.Round(kg/halfKg) * halfKg
 }

--- a/internal/exerciseprogression/progression.go
+++ b/internal/exerciseprogression/progression.go
@@ -51,7 +51,13 @@ const (
 	repsHypertrophy = 8
 	repsEndurance   = 15
 
-	weightIncrementKg     = 2.5
+	// dumbbellThresholdKg is the boundary below which loads progress in 1kg
+	// steps (matching real-world fixed-weight dumbbell sets) and at/above
+	// which they revert to the standard 2.5kg plate increment.
+	dumbbellThresholdKg = 10.0
+
+	weightIncrementKgLow  = 1.0
+	weightIncrementKgHigh = 2.5
 	weightDecrementFactor = 0.10
 	halfKg                = 0.5
 )
@@ -113,10 +119,11 @@ func TargetReps(t PeriodizationType) int {
 func adjustedWeight(last SetResult) float64 {
 	switch last.Signal {
 	case SignalTooLight:
-		return last.WeightKg + weightIncrementKg
+		return last.WeightKg + incrementFor(last.WeightKg)
 	case SignalTooHeavy:
-		decrement := math.Max(weightIncrementKg, math.Abs(last.WeightKg)*weightDecrementFactor)
-		return roundToHalf(last.WeightKg - decrement)
+		increment := incrementFor(last.WeightKg)
+		decrement := math.Max(increment, math.Abs(last.WeightKg)*weightDecrementFactor)
+		return snapWeight(last.WeightKg - decrement)
 	case SignalOnTarget:
 		return last.WeightKg
 	case SignalUnknown:
@@ -125,6 +132,20 @@ func adjustedWeight(last SetResult) float64 {
 	panic(fmt.Sprintf("exerciseprogression: unhandled Signal %d", last.Signal))
 }
 
-func roundToHalf(kg float64) float64 {
+// incrementFor returns the load step appropriate for the given weight: 1kg
+// inside the dumbbell range (|w| < 10kg), 2.5kg otherwise.
+func incrementFor(weight float64) float64 {
+	if math.Abs(weight) < dumbbellThresholdKg {
+		return weightIncrementKgLow
+	}
+	return weightIncrementKgHigh
+}
+
+// snapWeight rounds to the nearest realisable load: 1kg in the dumbbell
+// range, 0.5kg above.
+func snapWeight(kg float64) float64 {
+	if math.Abs(kg) < dumbbellThresholdKg {
+		return math.Round(kg)
+	}
 	return math.Round(kg/halfKg) * halfKg
 }

--- a/internal/exerciseprogression/progression_test.go
+++ b/internal/exerciseprogression/progression_test.go
@@ -252,7 +252,7 @@ func TestAdjustedWeight_AssistedAndZeroBoundary(t *testing.T) {
 			name:       "zero TooHeavy goes negative (zero boundary fixed)",
 			lastWeight: 0.0,
 			signal:     exerciseprogression.SignalTooHeavy,
-			wantWeight: -2.5,
+			wantWeight: -1.0,
 		},
 		{
 			name:       "negative TooLight goes less negative (less assistance)",
@@ -267,10 +267,10 @@ func TestAdjustedWeight_AssistedAndZeroBoundary(t *testing.T) {
 			wantWeight: -20.0,
 		},
 		{
-			name:       "low positive TooHeavy uses 2.5kg minimum decrement",
+			name:       "threshold weight TooHeavy uses 2.5kg increment and snaps to whole kg",
 			lastWeight: 10.0,
 			signal:     exerciseprogression.SignalTooHeavy,
-			wantWeight: 7.5,
+			wantWeight: 8.0, // 10 - max(2.5, 1.0) = 7.5; below threshold, snaps to 8.
 		},
 		{
 			name:       "high positive TooHeavy uses percentage (regression)",
@@ -283,6 +283,42 @@ func TestAdjustedWeight_AssistedAndZeroBoundary(t *testing.T) {
 			lastWeight: 50.0,
 			signal:     exerciseprogression.SignalTooHeavy,
 			wantWeight: 45.0,
+		},
+		{
+			name:       "dumbbell-range TooLight increases by 1kg",
+			lastWeight: 5.0,
+			signal:     exerciseprogression.SignalTooLight,
+			wantWeight: 6.0,
+		},
+		{
+			name:       "dumbbell-range TooLight at 9kg lands on 10kg threshold",
+			lastWeight: 9.0,
+			signal:     exerciseprogression.SignalTooLight,
+			wantWeight: 10.0,
+		},
+		{
+			name:       "zero TooLight increases by 1kg",
+			lastWeight: 0.0,
+			signal:     exerciseprogression.SignalTooLight,
+			wantWeight: 1.0,
+		},
+		{
+			name:       "dumbbell-range TooHeavy decreases by 1kg",
+			lastWeight: 5.0,
+			signal:     exerciseprogression.SignalTooHeavy,
+			wantWeight: 4.0,
+		},
+		{
+			name:       "dumbbell-range TooHeavy at 1kg lands on 0kg",
+			lastWeight: 1.0,
+			signal:     exerciseprogression.SignalTooHeavy,
+			wantWeight: 0.0,
+		},
+		{
+			name:       "threshold TooLight crosses into 2.5kg increment",
+			lastWeight: 10.0,
+			signal:     exerciseprogression.SignalTooLight,
+			wantWeight: 12.5,
 		},
 	}
 

--- a/internal/exerciseprogression/progression_test.go
+++ b/internal/exerciseprogression/progression_test.go
@@ -320,6 +320,12 @@ func TestAdjustedWeight_AssistedAndZeroBoundary(t *testing.T) {
 			signal:     exerciseprogression.SignalTooLight,
 			wantWeight: 12.5,
 		},
+		{
+			name:       "off-grid override TooLight snaps to whole kg",
+			lastWeight: 7.5, // user override; not a real fixed dumbbell.
+			signal:     exerciseprogression.SignalTooLight,
+			wantWeight: 9.0, // 7.5 + 1 = 8.5 → snaps to 9.
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -1238,14 +1238,14 @@ func Test_BuildProgression(t *testing.T) {
 		t.Fatalf("RecordSetCompletion: %v", err)
 	}
 
-	// Rebuild: next set should be 0 + 2.5 = 2.5 kg.
+	// Rebuild: next set should be 0 + 1 = 1 kg (1kg increment in dumbbell range).
 	prog, err = svc.BuildProgression(ctx, date, exerciseID)
 	if err != nil {
 		t.Fatalf("BuildProgression after set 1: %v", err)
 	}
 	target = prog.CurrentSet()
-	if target.WeightKg != 2.5 {
-		t.Errorf("second set weight: want 2.5, got %v", target.WeightKg)
+	if target.WeightKg != 1.0 {
+		t.Errorf("second set weight: want 1.0, got %v", target.WeightKg)
 	}
 }
 


### PR DESCRIPTION
Sub-10kg loads now step in 1kg jumps (matching real fixed-weight dumbbell
sets) instead of the universal 2.5kg plate increment. At/above 10kg the
existing 2.5kg increment is preserved. Snapping likewise rounds to whole
kg in the dumbbell range and 0.5kg above.