### PR TITLE
Scale assisted weight across rep schemes

### DIFF
--- a/internal/exerciseprogression/conversion.go
+++ b/internal/exerciseprogression/conversion.go
@@ -5,13 +5,23 @@ package exerciseprogression
 // realisable load (1kg in the dumbbell range, 0.5kg above). It uses the
 // Epley formula: 1RM = w * (1 + r/30).
 //
-// Returns weight unchanged when fromReps == toReps, or when any input is
-// non-positive. Non-positive weights cover assisted exercises (negative
-// weight_kg representing assistance), where there is no meaningful 1RM
-// analog — the assistance value is preserved verbatim across periodizations.
+// For positive weights, more reps map to a lighter load (e.g. 100 kg x5 →
+// ~92 kg x8). For negative weights — the assisted-exercise convention where
+// weight_kg is the magnitude of machine assistance — the scaling is inverted:
+// more reps require more assistance, so the magnitude grows (e.g. -50 kg x5
+// → ~-54.5 kg x8). Without a tracked bodyweight we cannot compute the true
+// effective load, but inverting the Epley ratio keeps the directional change
+// consistent with the within-session TooHeavy/TooLight behaviour.
+//
+// Returns weight unchanged when fromReps == toReps, when fromReps or toReps
+// are non-positive, or when weight is exactly zero (no scaling reference).
 func ConvertWeight(weight float64, fromReps, toReps int) float64 {
-	if weight <= 0 || fromReps <= 0 || toReps <= 0 || fromReps == toReps {
+	if weight == 0 || fromReps <= 0 || toReps <= 0 || fromReps == toReps {
 		return weight
+	}
+	if weight < 0 {
+		converted := weight * (1 + float64(toReps)/30) / (1 + float64(fromReps)/30)
+		return snapWeight(converted)
 	}
 	oneRepMax := weight * (1 + float64(fromReps)/30)
 	converted := oneRepMax / (1 + float64(toReps)/30)

--- a/internal/exerciseprogression/conversion_test.go
+++ b/internal/exerciseprogression/conversion_test.go
@@ -71,11 +71,32 @@ func TestConvertWeight(t *testing.T) {
 			want:     0.0,
 		},
 		{
-			name:     "negative weight returned unchanged",
+			name:     "assisted strength -50kg x5 to hypertrophy 8 reps adds assistance",
+			weight:   -50.0,
+			fromReps: 5,
+			toReps:   8,
+			want:     -54.5, // -50 * (1 + 8/30) / (1 + 5/30) ≈ -54.29 → snaps to -54.5.
+		},
+		{
+			name:     "assisted hypertrophy -50kg x8 to strength 5 reps removes assistance",
+			weight:   -50.0,
+			fromReps: 8,
+			toReps:   5,
+			want:     -46.0, // -50 * (1 + 5/30) / (1 + 8/30) ≈ -46.05 → snaps to -46.0.
+		},
+		{
+			name:     "assisted strength -50kg x5 to endurance 15 reps adds more assistance",
+			weight:   -50.0,
+			fromReps: 5,
+			toReps:   15,
+			want:     -64.5, // -50 * (1 + 15/30) / (1 + 5/30) ≈ -64.29 → snaps to -64.5.
+		},
+		{
+			name:     "assisted dumbbell-range -5kg x5 to 8 reps snaps to whole kg",
 			weight:   -5.0,
 			fromReps: 5,
 			toReps:   8,
-			want:     -5.0,
+			want:     -5.0, // -5 * 38/35 ≈ -5.43 → snaps to -5.
 		},
 		{
 			name:     "zero fromReps returned unchanged",

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -1075,6 +1075,93 @@ func Test_GetStartingWeight(t *testing.T) {
 	}
 }
 
+// Test_GetStartingWeight_Assisted covers the assisted-exercise (negative weight)
+// flow across periodization changes: an on-target -50 kg x5 strength set must
+// translate into a more negative weight when the next session is hypertrophy
+// (8 reps), since more reps require more machine assistance for the same
+// relative intensity.
+func Test_GetStartingWeight_Assisted(t *testing.T) {
+	ctx := t.Context()
+	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))
+	db, err := sqlite.NewDatabase(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var userID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		"INSERT INTO users (webauthn_user_id, display_name) VALUES (?, ?) RETURNING id",
+		[]byte("sw-assisted-user"), "SW Assisted User").Scan(&userID)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
+	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
+
+	_, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO exercises (name, category, description_markdown) VALUES (?, ?, ?)",
+		"Assisted Test Exercise", "upper", "desc")
+	if err != nil {
+		t.Fatalf("insert exercise: %v", err)
+	}
+	var exerciseID int
+	err = db.ReadOnly.QueryRowContext(ctx,
+		"SELECT id FROM exercises WHERE name = 'Assisted Test Exercise'").Scan(&exerciseID)
+	if err != nil {
+		t.Fatalf("get exercise id: %v", err)
+	}
+
+	svc := workout.NewService(db, logger, "")
+
+	today := time.Now()
+
+	// Insert a completed strength session 7 days ago at -50 kg x5, on target.
+	dateStr := today.AddDate(0, 0, -7).Format("2006-01-02")
+	_, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO workout_sessions (user_id, workout_date, completed_at, periodization_type)
+		 VALUES (?, ?, STRFTIME('%Y-%m-%dT%H:%M:%fZ'), 'strength')`,
+		userID, dateStr)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	var weHistID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		`INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id) VALUES (?, ?, ?) RETURNING id`,
+		userID, dateStr, exerciseID).Scan(&weHistID)
+	if err != nil {
+		t.Fatalf("insert workout_exercise: %v", err)
+	}
+	_, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
+		 weight_kg, min_reps, max_reps, completed_reps, signal)
+		 VALUES (?, 1, -50.0, 5, 5, 5, 'on_target')`,
+		weHistID)
+	if err != nil {
+		t.Fatalf("insert sets: %v", err)
+	}
+
+	// Same periodization: -50 kg carries over unchanged.
+	got, err := svc.GetStartingWeight(ctx, exerciseID, today, workout.PeriodizationStrength)
+	if err != nil {
+		t.Fatalf("GetStartingWeight strength→strength: %v", err)
+	}
+	if got != -50.0 {
+		t.Errorf("assisted strength → strength: want -50.0, got %v", got)
+	}
+
+	// Cross-periodization (strength 5 reps → hypertrophy 8 reps): more reps
+	// require more assistance, so the recommendation must be more negative.
+	// -50 * (1 + 8/30) / (1 + 5/30) ≈ -54.29 → snaps to -54.5.
+	got, err = svc.GetStartingWeight(ctx, exerciseID, today, workout.PeriodizationHypertrophy)
+	if err != nil {
+		t.Fatalf("GetStartingWeight strength→hypertrophy: %v", err)
+	}
+	if got != -54.5 {
+		t.Errorf("assisted strength → hypertrophy: want -54.5, got %v", got)
+	}
+}
+
 func Test_RecordSetCompletion(t *testing.T) {
 	ctx := t.Context()
 	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))


### PR DESCRIPTION
ConvertWeight previously returned negative weights verbatim, so an
on-target -50 kg x5 strength session translated to -50 kg x8 hypertrophy
the next week — at the same assistance the user has to grind out three
more reps, which is harder, not iso-intensity. The within-session
adjustedWeight already moves the right direction (TooHeavy on -50 → -55),
but the cross-periodization seed in GetStartingWeight bypassed it.

Apply the inverse Epley ratio when weight < 0: more reps → more
assistance magnitude. -50 kg x5 → ~-54.5 kg x8, -50 kg x8 → -46 kg x5.
Without a tracked bodyweight we can't compute the true effective load,
but inverting the ratio keeps the recommendation directionally correct
and consistent with the within-session signal handling.