### PR TITLE
Add design specs for attribute-driven planner

### DIFF
--- a/specs/01-exercise-attributes.md
+++ b/specs/01-exercise-attributes.md
@@ -1,0 +1,133 @@
+# Attribute-Driven Exercise Classification
+
+## Motivation
+
+Today the planner derives rep targets from a single per-session knob —
+`PeriodizationType` — applied uniformly across every exercise in
+`internal/exerciseprogression/progression.go:50-52`:
+
+```
+Strength    = 5 reps
+Hypertrophy = 8 reps
+Endurance   = 15 reps
+```
+
+This produces wrong prescriptions for entire classes of exercise:
+
+- **Heavy 5-rep back extensions** load the lumbar spine in shear — high injury
+  risk for marginal adaptation. Established practice (NSCA, Renaissance
+  Periodization, Stronger By Science) reserves <6-rep work for big compound
+  patterns where the loaded-spine motor pattern is itself the goal.
+- **5-rep calf raises** under-stimulate the soleus, which is ~70–90 % slow-twitch
+  and grows from 15–25 reps with longer time-under-tension.
+- **5-rep ab wheel rollouts** are nonsense — the rollout is anti-extension
+  isometric stability work; the progression that matters is lever length
+  (kneeling → standing) and ROM, not load.
+- **8-rep deadlifts** in a hypertrophy mesocycle keep the spinal-load fatigue
+  cost without the SBD-pattern strength reward.
+
+The fix is **not** more periodization types. It is to give each exercise enough
+attributes to *derive* a sensible rep range, then drive the progression engine
+from those attributes instead of from the periodization constant alone.
+
+## What we're adding
+
+A small, fixed vocabulary of attributes on `exercises`, set once per row in
+`fixtures.sql` and read by a pure derivation function:
+
+| Attribute            | Values                                                              | Drives                                              |
+|----------------------|---------------------------------------------------------------------|-----------------------------------------------------|
+| `loading_type`       | compound / isolation / isometric_stability / plyometric / carry     | Whether reps or duration; whether load is the axis  |
+| `spinal_load`        | none / low / moderate / high / very_high                            | Floor on rep range; clamps strength prescriptions   |
+| `skill_demand`       | low / moderate / high                                               | RIR conservatism for novices                        |
+| `rom_sensitivity`    | low / moderate / high                                               | Whether tempo is a meaningful progression axis      |
+| `tempo_sensitivity`  | low / moderate / high                                               | Whether eccentric tempo should be prescribed        |
+| `default_rep_min/max`| nullable integers                                                   | Per-exercise override of the periodization default  |
+
+All are `TEXT CHECK (... IN (...))` enums, idiomatic in this STRICT-mode SQLite
+codebase (`internal/sqlite/schema.sql:81-88` already uses this pattern for
+`category` and `exercise_type`).
+
+## Key design decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Storage | New columns on `exercises` (no sibling table) | All attributes are 1:1 with the exercise; a join buys nothing |
+| Defaults | Sensible per-attribute defaults via `DEFAULT` clauses | Existing rows in `fixtures.sql` upsert cleanly without a values audit blocking the migration |
+| Derivation | Pure Go function `DeriveRepScheme(Exercise, PeriodizationType) RepScheme` | Unit-testable without DB; one place to change the prescription model |
+| Override path | `default_rep_min/max` win over the periodization default | Lets the seed encode "calves are always 15+ regardless of mesocycle" |
+| Periodization stays | Keep the existing `PeriodizationType` enum | It's still the macro lever — strength/hypertrophy now *modulates* rather than *dictates* |
+| No new feedback | Continue using the existing `Signal` enum | Attribute-driven prescription is independent of how the user reports effort |
+
+## High-level shape
+
+```go
+// internal/exerciseprogression/repscheme.go (new)
+
+type RepScheme struct {
+    RepsMin     int
+    RepsMax     int
+    RestSeconds int
+}
+
+// DeriveRepScheme is pure: same inputs → same output, no DB, no clock.
+func DeriveRepScheme(ex Exercise, p PeriodizationType) RepScheme
+```
+
+Derivation rules apply in this order, last write wins:
+
+1. Start from the periodization default (5 / 8 / 15).
+2. If `default_rep_min/max` are set on the exercise, override.
+3. If `spinal_load` ≥ `high` and `p == Strength`, clamp `RepsMin` to ≥ 5.
+4. If `loading_type == isometric_stability`, force the range to 6–12 with a
+   strict-form flag.
+5. Rest follows the *final* range, not the periodization: ≤8 reps → 2.5–4 min,
+   9–15 → 90–120 s, 16+ → 60–90 s.
+
+The progression engine in `progression.go` stops calling `TargetReps(t)` and
+instead asks `DeriveRepScheme` for the range. The `Signal` autoregulation
+loop is unchanged.
+
+## Seed audit
+
+Before merging, audit the ~20 highest-error-rate exercises in `fixtures.sql`.
+The shortlist (rows that the goal-keyed system reliably gets wrong):
+
+- Back extension, good morning, RDL, conventional deadlift, back squat, front squat
+- Standing calf raise, seated calf raise
+- Ab wheel rollout, plank, Pallof press, hanging leg raise, cable crunch
+- Pistol squat, Nordic curl, Bulgarian split squat
+- Bench press, pull-up, lateral raise, face pull, wrist curl, farmer's carry
+
+Rest of the catalogue can take attribute defaults and be revisited later.
+
+## Out of scope
+
+- Per-muscle fiber profile (covered in `02-volume-bands.md`).
+- Multi-axis progression — the rep range coming out of `DeriveRepScheme` is
+  still single-axis (load) for now (covered in `03-multi-axis-progression.md`).
+- A rules engine. The five rules above are short enough that an inline
+  switch in `DeriveRepScheme` is the readable choice. Defer the engine until
+  the rule count exceeds ~10.
+
+## Acceptance
+
+- A table-driven test in `repscheme_test.go` covers ≥30 (exercise,
+  periodization) pairs with hand-picked expected ranges, including: deadlift in
+  Hypertrophy stays ≤6, calf raise in Strength stays ≥12, ab rollout in any
+  periodization is 6–12.
+- Manual eyeball of 10 generated weeks shows none of the previously-wrong
+  prescriptions surfacing.
+
+## Brainstorming starter prompt
+
+> I want to brainstorm `specs/01-exercise-attributes.md`. Walk me through the
+> attribute set: are these the right six attributes, are the enum values right,
+> and is there any attribute I'm missing that would let the seed encode the
+> ~20 high-error-rate exercises faithfully? Then sanity-check the
+> `DeriveRepScheme` rule order and clamp logic against the example exercises
+> in the seed audit. Finally, identify the tradeoffs of putting all six
+> attributes directly on `exercises` versus a sibling table or JSON blob.
+> The codebase is Go + STRICT-mode SQLite with a single `schema.sql`; idiomatic
+> patterns are visible in `internal/sqlite/schema.sql` and
+> `internal/exerciseprogression/progression.go`.

--- a/specs/02-volume-bands.md
+++ b/specs/02-volume-bands.md
@@ -1,0 +1,132 @@
+# Per-Muscle Volume Bands (MEV / MAV / MRV)
+
+## Motivation
+
+The week planner currently allocates muscle groups to days using a single
+`weekly_sets_target` integer per muscle on `muscle_group_weekly_targets`
+(see `internal/weekplanner/weekplanner.go:235`). This conflates three
+quantities that the training-science literature treats as distinct:
+
+- **MEV** — *Minimum Effective Volume*. Below this, no growth.
+- **MAV** — *Maximum Adaptive Volume*. The sweet spot.
+- **MRV** — *Maximum Recoverable Volume*. Above this, fatigue outpaces
+  adaptation.
+
+Renaissance Periodization, Schoenfeld's meta-analyses, and Stronger By Science
+converge on these landmarks as the most defensible heuristic for setting weekly
+sets per muscle. They also vary substantially by muscle: soleus tolerates
+~22 sets/wk MRV, spinal erectors ~12. A single integer can't represent that.
+
+The user-visible payoff is two things:
+
+1. The planner stops over- or under-dosing muscle groups regardless of what's
+   already on the calendar. Today, if Tuesday and Friday both target lats with
+   pull-ups + rows, the planner happily piles ~24 sets onto lats with no signal
+   that this is past MRV.
+2. A weekly volume bar per muscle (green inside MAV, yellow approaching MRV,
+   red over) becomes a free product feature that competitors (RP Hypertrophy)
+   sell as their primary differentiator. The data is already there once we
+   widen the schema.
+
+## What we're adding
+
+A 3-column widening of the existing target table, plus an awareness pass in
+the week planner:
+
+```sql
+-- before
+weekly_sets_target INTEGER NOT NULL
+
+-- after
+weekly_mev_sets INTEGER NOT NULL,
+weekly_mav_sets INTEGER NOT NULL,
+weekly_mrv_sets INTEGER NOT NULL
+```
+
+Defensible defaults to seed with (RP/Schoenfeld-aligned):
+
+| Muscle group       | MEV | MAV | MRV |
+|--------------------|-----|-----|-----|
+| Quadriceps         | 8   | 14  | 20  |
+| Hamstrings         | 6   | 12  | 16  |
+| Glutes             | 4   | 10  | 16  |
+| Calves (combined)  | 8   | 14  | 22  |
+| Pectorals          | 8   | 14  | 22  |
+| Lats               | 8   | 14  | 22  |
+| Biceps             | 6   | 12  | 20  |
+| Triceps            | 6   | 12  | 18  |
+| Lateral deltoid    | 8   | 16  | 26  |
+| Rear deltoid       | 6   | 14  | 22  |
+| Spinal erectors    | 4   | 8   | 12  |
+| Abs                | 6   | 14  | 25  |
+
+The week planner's `allocateMuscleGroups` (line 235) consults MEV as the
+floor (must hit) and MRV as the ceiling (must not exceed) instead of greedily
+matching a single target.
+
+## Key design decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Schema shape | Widen the existing table; don't add a new one | One row per (user_id, muscle_group) is still the right grain |
+| Per-user vs. global | Keep per-user; seed defaults at user-create time | Bands are personalised over time as users progress; defaults come from the catalogue |
+| Migration | Edit `schema.sql` and add a one-shot `docs/YYYY-MM-DD-volume-bands.sql` to backfill existing rows | Matches the project's declarative migration pattern (see CLAUDE.md) |
+| Set-counting | Reuse the existing per-set rows in `exercise_sets`; secondary-muscle sets count fractionally (0.5×) | Follows Schoenfeld's "fractional set" heuristic without needing a new contribution column today |
+| Planner contract | MEV is a floor, MRV is a hard ceiling, MAV is a target — the existing greedy allocator is replaced with band-aware selection | Makes the bands actually shape decisions, not just decorate them |
+| UI surfacing | Per-muscle bar on the week view, color-coded green/yellow/red | The whole point — invisible bands aren't worth the migration |
+
+## High-level shape
+
+A single new query method on the workout repository:
+
+```go
+// WeeklyVolumeByMuscle returns effective sets logged in the trailing 7 days,
+// keyed by muscle group, including fractional credit for secondary muscles.
+WeeklyVolumeByMuscle(userID int64, asOf time.Time) map[MuscleGroupID]float64
+```
+
+Plumbs into `weekplanner` with a single decision rule per slot:
+
+```
+for each candidate exercise for this slot:
+    projected = current_volume + sets_this_session
+    if projected > muscle.MRV → reject
+    score adds bonus if current_volume < muscle.MEV (must-hit)
+    score subtracts penalty as projected approaches muscle.MRV
+pick highest-scoring candidate
+```
+
+That's the whole policy. No optimization solver, no rules engine.
+
+## Out of scope
+
+- **Adaptive bands** that learn from user response. Defer — start with seeded
+  defaults; revisit when ≥1k users have logged ≥1 mesocycle each.
+- **Per-head muscle granularity** (front vs. side vs. rear delts). The seed
+  table above already separates lateral and rear delts, which is the most
+  important split. Sub-pec heads, sub-tricep heads etc. are too fine-grained
+  for the current exercise catalogue.
+- **Soft caps and override workflow.** MRV is treated as a hard rejection.
+  If users complain, revisit by adding a "force include" affordance later.
+
+## Acceptance
+
+- Generated week for a synthetic user with 7 days/week of preferences keeps
+  every muscle inside `[MEV, MRV]` for ≥80 % of muscles, and never breaches MRV.
+- Week view renders a per-muscle bar for every tracked muscle with the correct
+  color band.
+
+## Brainstorming starter prompt
+
+> I want to brainstorm `specs/02-volume-bands.md`. Two things specifically:
+> (1) The seed defaults — are MEV/MAV/MRV right for the muscle groups we
+> currently track in `internal/sqlite/fixtures.sql`? Pull the catalogue and
+> propose any additions or splits (e.g., should we split calves into
+> gastrocnemius vs. soleus to make the soleus 22-set MRV actually addressable?).
+> (2) The "fractional sets for secondary muscles" rule — is a flat 0.5×
+> credit good enough, or do we need a per-exercise contribution weight on
+> `exercise_muscle_groups` to model e.g. romanian deadlifts contributing
+> ~0.7× to glutes? Reason in the codebase context: existing schema in
+> `internal/sqlite/schema.sql:135-153`, planner in
+> `internal/weekplanner/weekplanner.go:235`. Prefer the cheapest model that
+> still produces sensible weekly allocations.

--- a/specs/03-multi-axis-progression.md
+++ b/specs/03-multi-axis-progression.md
@@ -1,0 +1,177 @@
+# Multi-Axis Progression
+
+## Motivation
+
+Once `01-exercise-attributes.md` ships, the planner knows how many reps to
+*prescribe*. This document covers how to *progress* — i.e., what to change
+when the user feeds back `SignalTooLight` after hitting target.
+
+Today the answer is fixed: add weight. From
+`internal/exerciseprogression/progression.go:118-132`:
+
+```
+SignalTooLight  → weight += increment
+SignalOnTarget  → hold
+SignalTooHeavy  → weight -= max(increment, 10% of weight)
+```
+
+That is correct for the bench press and the deadlift. It is wrong for almost
+everything else:
+
+- **Calf raise**: jumping from 60 kg → 62.5 kg at 3×15 will fail. The right
+  next step is 3×17 at the same load. Reps then load.
+- **Ab wheel rollout**: there is no load to add. The right next step is
+  *kneeling-partial → kneeling-full → standing-partial → standing-full*.
+  Variant then ROM.
+- **Back extension**: under high spinal load, more weight is the dangerous
+  axis. The right next step is to slow the eccentric (3-1-1 → 4-0-1) before
+  adding load. Tempo then reps then load.
+- **Pistol squat**: a beginner can't load a pistol; what advances them is
+  band-assisted → unassisted-partial-ROM → unassisted-full-ROM. Variant then
+  ROM then load.
+
+A single-axis system either advances them dangerously (load on back
+extensions) or fails to advance them at all (rollouts that they can't even do
+from their knees yet keep showing the same prescription forever).
+
+## What we're adding
+
+A *priority list* per exercise that names the progression axes in the order
+the engine should try them. It lives on `exercises` as a single text column:
+
+```sql
+progression_axes TEXT NOT NULL DEFAULT 'load,reps'
+    -- comma-separated subset of: load, reps, rom, tempo, variant
+```
+
+Examples from the seed audit:
+
+| Exercise            | `progression_axes`         |
+|---------------------|----------------------------|
+| Conventional deadlift | `load`                   |
+| Bench press         | `load`                     |
+| Standing calf raise | `reps,load,tempo`          |
+| Seated calf raise   | `reps,load,tempo`          |
+| Back extension      | `tempo,reps,load`          |
+| Romanian deadlift   | `load,reps`                |
+| Ab wheel rollout    | `variant,rom,reps`         |
+| Pistol squat        | `variant,rom,reps,load`    |
+| Nordic curl         | `rom,variant,reps`         |
+| Pallof press        | `variant,load`             |
+| Lateral raise       | `reps,load`                |
+
+The progression engine asks: "is the first axis capped?" If yes, advance the
+next axis instead. *Capped* depends on the axis:
+
+- **load** is capped when the user override would jump to a non-loadable
+  weight (e.g. dumbbell pairs jumping 10 kg → 12.5 kg).
+- **reps** is capped at the top of `RepsMax` from `DeriveRepScheme`.
+- **rom** is capped at 100 % (full ROM).
+- **tempo** is capped at 4 s eccentric (a programmable max).
+- **variant** is capped when there is no harder variant in the chain.
+
+## Key design decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Encoding | One comma-separated text column on `exercises`, parsed at read time | A relational join (axes table) buys nothing; the list is short and read-only at runtime |
+| New columns on `exercise_sets` | `rom_pct INTEGER DEFAULT 100`, `tempo_eccentric_s INTEGER DEFAULT 0`, `variant_id INTEGER NULL` | Logging is what makes "did the user cap this axis?" answerable |
+| Variants | Sibling table `exercise_variants(exercise_id, name, difficulty_rank)` | Variant chains belong to an exercise; a sibling table keeps `exercises` clean |
+| Signal stays | Continue with the existing 3-bucket `Signal` enum | RIR sliders are friction; the bucket is enough to drive the priority list |
+| Algorithm shape | Pure function: `NextPrescription(ex, history) Prescription` | No DB, no clock, fully unit-testable — same shape as `DeriveRepScheme` |
+| De-load | If `RepsMin` missed for 2 consecutive sessions, step back one variant or –10 % load | Only de-load axis we ship; full mesocycle de-loads are out of scope |
+| No DSL | Inline `switch` over the parsed axis list | The Liftosaur DSL is overkill for a solo Go project; this fits in ~150 lines |
+
+## High-level shape
+
+```go
+// internal/exerciseprogression/progression.go (extended)
+
+type Axis string
+
+const (
+    AxisLoad    Axis = "load"
+    AxisReps    Axis = "reps"
+    AxisROM     Axis = "rom"
+    AxisTempo   Axis = "tempo"
+    AxisVariant Axis = "variant"
+)
+
+type Prescription struct {
+    WeightKg       float64
+    Reps           int
+    ROMPct         int
+    TempoEccS      int
+    VariantID      int64
+}
+
+// NextPrescription replaces adjustedWeight as the engine entry point.
+func NextPrescription(ex Exercise, scheme RepScheme, history []SetResult) Prescription
+```
+
+Pseudocode:
+
+```
+last := history[len-1]
+switch last.Signal:
+case OnTarget   → hold all axes, return last as-is
+case TooHeavy   → de-load the *current* axis (back off load, or back off ROM, or step
+                  back a variant); rest unchanged
+case TooLight   → for each axis in ex.progression_axes:
+                      if axis is not capped, advance it and return
+                  → all axes capped: hold (the user has graduated this exercise)
+```
+
+The existing `Signal`-driven code path becomes one branch (the
+`progression_axes == "load"` case) of this function.
+
+## Concrete progression examples
+
+The contract this delivers for the seed audit:
+
+- **Calf raise** (`reps,load,tempo`): hits 3×15 → next session 3×18; hits 3×20
+  → +5 kg, drop reps to 12; eventually cap reps at 25 → switch to slowing the
+  eccentric.
+- **Deadlift** (`load`): hits 3×5 → +2.5 kg next session. Reps stay at 5. The
+  SBD strength profile is preserved.
+- **Back extension** (`tempo,reps,load`): hits 3×12 with 1-1-1 → next session
+  3×12 at 3-1-1; then 3×15 at 3-1-1; then add 5 kg, reset to 3×12 with 1-1-1.
+- **Ab wheel rollout** (`variant,rom,reps`): three sessions of 3×8 kneeling-
+  partial → advance variant to kneeling-full, restart at 3×6.
+- **Nordic curl** (`rom,variant,reps`): hits 3×5 at 60 % ROM → next session
+  3×5 at 75 % ROM; eventually 100 % ROM → advance variant to weighted Nordic.
+
+## Out of scope
+
+- **Per-set rationale tracking.** Captured in `04-prescription-rationale.md`.
+- **Mesocycle-level de-loads** (RP-style 4-week accumulation + 1 de-load week).
+  This doc only covers within-progression regression on consecutive misses.
+- **RIR/RPE picker.** Defer; see `01-exercise-attributes.md`.
+- **Equipment profiles for variants.** Variants are seeded with their own
+  equipment requirements; the planner respects the existing `exercise_type`
+  flag without learning about gym profiles yet.
+- **Within-session adjustments** (Liftosaur's `update` blocks). Out of scope —
+  current `recordSetCompletionWithWeight` flow is enough.
+
+## Acceptance
+
+- A property test asserts: progression never *skips* a variant level upward;
+  on `TooHeavy` after two failures it backs off exactly one step on the active
+  axis, never silently advances another.
+- A 4-week synthetic mesocycle test for each example above produces the
+  prescriptions listed under "Concrete progression examples".
+
+## Brainstorming starter prompt
+
+> I want to brainstorm `specs/03-multi-axis-progression.md`. Three things:
+> (1) The five axes — is `load,reps,rom,tempo,variant` the complete set, or
+> am I missing one (e.g., set count, rest interval)? (2) The variant model —
+> seeding `exercise_variants` for ab wheel, pistol squat, Nordic curl, and
+> pull-up. Walk me through the chain you'd seed for each, including the
+> `prerequisites` for advancing (e.g., "min 3 sessions at the prior variant
+> hitting `RepsMax`"). (3) The de-load policy on `TooHeavy` — should we step
+> back the *active* axis only, or always step back load first regardless of
+> the priority list, since load is the most reversible failure mode? Codebase
+> context: `internal/exerciseprogression/progression.go:118-132` for the
+> existing single-axis logic, `internal/sqlite/schema.sql:121-133` for
+> `exercise_sets`. Keep the design inline — no DSL, no rules engine.

--- a/specs/04-prescription-rationale.md
+++ b/specs/04-prescription-rationale.md
@@ -1,0 +1,130 @@
+# Per-Prescription Rationale
+
+## Motivation
+
+Once the prescription engine has attributes, volume bands, and a multi-axis
+progression policy, the user gets a noticeably smarter plan — but they have
+no idea *why* it changed. The state of the art in commercial planners is
+remarkably poor on this front:
+
+- **RP Hypertrophy** explains *what* it did (added a set; you're in a de-load)
+  but not *why* in this specific user's data.
+- **Fitbod** shows a recovery heat-map but doesn't tie exercise selection
+  back to it.
+- **Hevy Trainer** auto-progresses silently — App Store reviews repeatedly
+  cite "I don't know why my weight didn't go up this week".
+- **Liftosaur** is transparent only because the program is plain text the
+  user can read; the system itself doesn't explain.
+
+This is a free product win for petrapp: every prescription change is already
+the output of a deterministic rule. If we capture *which rule fired and on
+what input*, we get a one-line user-facing rationale at zero algorithmic
+cost. It is the cheapest differentiation available, and it is what makes the
+planner feel competent rather than magical.
+
+## What we're adding
+
+A single nullable `TEXT` column on the row that already exists for prescribed
+sets, plus a small per-axis writer in the progression engine.
+
+```sql
+-- exercise_sets, prescribed columns are already on the row
+rationale TEXT  -- nullable, < 256 chars
+```
+
+Examples of rationales the engine emits:
+
+| Situation                                              | Rationale string                                                         |
+|--------------------------------------------------------|---------------------------------------------------------------------------|
+| First time seeing this exercise                        | `Starting weight from history average; reps from hypertrophy default.`    |
+| `SignalTooLight` advanced load                         | `+2.5 kg — last session beat the rep target.`                             |
+| `SignalTooLight` capped on load, advanced reps         | `+2 reps — load already at next dumbbell jump; reps cheaper than skipping a size.` |
+| Spinal-load clamp prevented a 3-rep prescription       | `Reps held at 8 — back extension carries high spinal load; staying ≥6 reps.` |
+| Slow-twitch shift on calf raise                        | `Reps shifted to 15–20 — soleus is slow-twitch dominant.`                 |
+| MRV ceiling rejected a candidate                       | `Skipping cable row — lats already at 22/22 sets this week (MRV).`        |
+| Variant advancement                                    | `Advanced to standing partial — completed 3 sessions of kneeling full at top reps.` |
+| De-load on consecutive misses                          | `–10 % load — failed rep target two sessions in a row.`                   |
+
+Three properties matter:
+
+1. **Single line, ≤ 256 chars.** Anything longer is unread. The rendered UI
+   surface is one row of light grey text under the prescribed weight × reps.
+2. **Built from the same inputs the rule used.** Don't write a separate
+   "explanation generator" that re-derives why; that's where commercial
+   apps go wrong (the explanation drifts from reality). The rule writes its
+   own rationale.
+3. **Stored, not recomputed.** History queries should be able to surface
+   "rationales for the last 4 weeks" without re-running the engine.
+
+## Key design decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Storage | Single nullable `TEXT` column on `exercise_sets` | The prescription/log fusion in this codebase means the row is already there; no new table |
+| Length cap | < 256 chars enforced in CHECK | Forces sentences, not paragraphs; matches the rest of `schema.sql` |
+| Authorship | The rule that fires writes the rationale; `DeriveRepScheme` and `NextPrescription` return `(Prescription, string)` | One source of truth — the rule and its explanation can't drift |
+| Composition | When multiple rules apply to one prescription, join with `; ` and cap to the first 256 chars | Keeps the contract simple; first rules listed are most important |
+| Localization | English-only initially | The whole app is English-only; revisit when i18n lands generally |
+| UI | Render under the prescribed line, dim text, no icon | Doesn't compete for attention with the actual targets |
+| History | Surface rationales in the per-exercise history view alongside set logs | Lets users see a story of "why this got harder over time" |
+
+## High-level shape
+
+The signature change is small but consistent:
+
+```go
+// before
+DeriveRepScheme(ex, p) RepScheme
+NextPrescription(ex, scheme, history) Prescription
+
+// after
+DeriveRepScheme(ex, p) (RepScheme, []string)
+NextPrescription(ex, scheme, history) (Prescription, []string)
+```
+
+Each rule that mutates the output appends one line. The handler joins the
+slice with `; ` and stores the result. If the slice is empty, the column
+stays NULL.
+
+The volume-band layer in `02-volume-bands.md` does the same when it rejects a
+candidate during selection, except those rationales attach to the
+*selection decision* (which exercise was chosen) rather than the
+prescription. To keep the schema minimal, store those on a sibling row in
+`workout_sessions` (a single per-session `selection_rationale TEXT`) — they're
+session-scoped, not set-scoped.
+
+## Out of scope
+
+- **End-of-mesocycle reports.** "Started at MEV=10, ended at 14 sets, weight
+  went up 5 kg" is real product gold but belongs in a separate spec.
+- **Causal explanation graphs.** The literature on explainable
+  recommendation (Zhang & Chen, 2018) covers richer formats. Template-based
+  rationales as above are sufficient for petrapp's audience and order of
+  magnitude cheaper to ship.
+- **User-overridable rationales.** If a user disagrees with the planner, the
+  fix is to override the prescription (already supported), not to argue with
+  the rationale.
+
+## Acceptance
+
+- Every prescription generated by `DeriveRepScheme` and `NextPrescription`
+  with a non-default behavior carries a non-empty rationale string.
+- Manual eyeball: pick 10 random recent sets in the per-exercise history
+  view and confirm each one's rationale reads as a complete English sentence
+  matching the user's data.
+- The rationale never references state the user can't see (no internal
+  variable names, no IDs).
+
+## Brainstorming starter prompt
+
+> I want to brainstorm `specs/04-prescription-rationale.md`. Two open
+> questions: (1) Voice and length — pull the example rationales table and
+> tell me which read as patronising, which read as useful, and how they'd
+> sound after seeing the same one for the tenth time. Should rationales
+> de-duplicate across consecutive identical sessions? (2) Where in the UI
+> the rationale should live — under the prescription line on the
+> exerciseset page, or only revealed on tap to keep the primary view clean.
+> Codebase context: prescription rendering happens in
+> `ui/templates/pages/exerciseset/sets-container.gohtml` and
+> `cmd/web/handler-exerciseset.go`. Push back hard if a rationale is
+> ever going to be more useful as silence.


### PR DESCRIPTION
Four high-level design docs in specs/ covering the staged plan to evolve the
planner from single-axis load progression to attribute-driven prescription:

- 01-exercise-attributes.md: classify exercises by spinal load, fiber profile,
  skill demand, ROM/tempo sensitivity; replace fixed rep constants with a
  pure DeriveRepScheme function.
- 02-volume-bands.md: widen muscle_group_weekly_targets to MEV/MAV/MRV; make
  the week planner band-aware.
- 03-multi-axis-progression.md: add a per-exercise progression_axes priority
  list (load, reps, ROM, tempo, variant); progress whichever axis is uncapped.
- 04-prescription-rationale.md: each rule that fires writes its own one-line
  rationale; surface in UI alongside the prescribed set.

Each doc ends with a suggested superpowers brainstorming prompt for the
follow-up sessions.

https://claude.ai/code/session_01NS81nPKubyf3uPds6PVm3x