### PR TITLE
Add time-based exercise type (plank holds for duration)

### DIFF
--- a/cmd/web/handler-admin-exercises.go
+++ b/cmd/web/handler-admin-exercises.go
@@ -26,10 +26,11 @@ type MuscleGroupOption struct {
 // exerciseEditTemplateData contains data for the exercise edit template.
 type exerciseEditTemplateData struct {
 	BaseTemplateData
-	Exercise               workout.Exercise
-	PrimaryMuscleOptions   []MuscleGroupOption
-	SecondaryMuscleOptions []MuscleGroupOption
-	ValidationError        string
+	Exercise                    workout.Exercise
+	PrimaryMuscleOptions        []MuscleGroupOption
+	SecondaryMuscleOptions      []MuscleGroupOption
+	ValidationError             string
+	DefaultStartingSecondsValue string
 }
 
 // adminExercisesGET handles GET requests to the exercise admin page.
@@ -99,12 +100,18 @@ func (app *application) adminExerciseEditGET(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
+	defaultSecondsValue := ""
+	if exercise.DefaultStartingSeconds != nil {
+		defaultSecondsValue = strconv.Itoa(*exercise.DefaultStartingSeconds)
+	}
+
 	data := exerciseEditTemplateData{
-		BaseTemplateData:       newBaseTemplateData(r),
-		Exercise:               exercise,
-		PrimaryMuscleOptions:   primaryMuscleOptions,
-		SecondaryMuscleOptions: secondaryMuscleOptions,
-		ValidationError:        app.popFlashError(r.Context()),
+		BaseTemplateData:            newBaseTemplateData(r),
+		Exercise:                    exercise,
+		PrimaryMuscleOptions:        primaryMuscleOptions,
+		SecondaryMuscleOptions:      secondaryMuscleOptions,
+		ValidationError:             app.popFlashError(r.Context()),
+		DefaultStartingSecondsValue: defaultSecondsValue,
 	}
 
 	app.render(w, r, http.StatusOK, "admin-exercise-edit", data)
@@ -152,10 +159,23 @@ func (app *application) adminExerciseUpdatePOST(w http.ResponseWriter, r *http.R
 
 	if exerciseType != workout.ExerciseTypeWeighted &&
 		exerciseType != workout.ExerciseTypeBodyweight &&
-		exerciseType != workout.ExerciseTypeAssisted {
-		app.putFlashError(r.Context(), "Exercise type must be weighted, bodyweight, or assisted.")
+		exerciseType != workout.ExerciseTypeAssisted &&
+		exerciseType != workout.ExerciseTypeTime {
+		app.putFlashError(r.Context(), "Exercise type must be weighted, bodyweight, assisted, or time_based.")
 		redirect(w, r, editPath)
 		return
+	}
+
+	var defaultStartingSeconds *int
+	if exerciseType == workout.ExerciseTypeTime {
+		raw := r.PostForm.Get("default_starting_seconds")
+		n, atoiErr := strconv.Atoi(raw)
+		if atoiErr != nil || n <= 0 {
+			app.putFlashError(r.Context(), "Default starting seconds must be a positive integer for time-based exercises.")
+			redirect(w, r, editPath)
+			return
+		}
+		defaultStartingSeconds = &n
 	}
 
 	if len(primaryMuscles) == 0 {
@@ -165,14 +185,15 @@ func (app *application) adminExerciseUpdatePOST(w http.ResponseWriter, r *http.R
 	}
 
 	// Create exercise object.
-	exercise := workout.Exercise{ //nolint:exhaustruct // DefaultStartingSeconds is not managed by this form (Task 9).
-		ID:                    id,
-		Name:                  name,
-		Category:              category,
-		ExerciseType:          exerciseType,
-		DescriptionMarkdown:   description,
-		PrimaryMuscleGroups:   primaryMuscles,
-		SecondaryMuscleGroups: secondaryMuscles,
+	exercise := workout.Exercise{
+		ID:                     id,
+		Name:                   name,
+		Category:               category,
+		ExerciseType:           exerciseType,
+		DescriptionMarkdown:    description,
+		PrimaryMuscleGroups:    primaryMuscles,
+		SecondaryMuscleGroups:  secondaryMuscles,
+		DefaultStartingSeconds: defaultStartingSeconds,
 	}
 
 	// Update exercise

--- a/cmd/web/handler-admin-exercises.go
+++ b/cmd/web/handler-admin-exercises.go
@@ -164,8 +164,8 @@ func (app *application) adminExerciseUpdatePOST(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Create exercise object
-	exercise := workout.Exercise{
+	// Create exercise object.
+	exercise := workout.Exercise{ //nolint:exhaustruct // DefaultStartingSeconds is not managed by this form (Task 9).
 		ID:                    id,
 		Name:                  name,
 		Category:              category,

--- a/cmd/web/handler-exercise-info.go
+++ b/cmd/web/handler-exercise-info.go
@@ -109,18 +109,20 @@ func processEntryData(entry workout.ExerciseProgressEntry, typ workout.ExerciseT
 	var setDescriptions []string
 
 	for _, set := range entry.Sets {
-		reps := *set.CompletedReps // service guarantees CompletedReps != nil
-
 		switch typ {
 		// Weighted and assisted share the same metric: signed weight.
 		// `-20 → -10 → 0 → +5` describes a continuous progression.
 		case workout.ExerciseTypeWeighted, workout.ExerciseTypeAssisted:
-			if set.WeightKg != nil {
+			if set.WeightKg != nil && set.CompletedValue != nil {
 				weight := *set.WeightKg
-				setDescriptions = append(setDescriptions, fmt.Sprintf("%dx%.1fkg", reps, weight))
+				setDescriptions = append(setDescriptions, fmt.Sprintf("%dx%.1fkg", *set.CompletedValue, weight))
 			}
 		case workout.ExerciseTypeBodyweight:
-			setDescriptions = append(setDescriptions, fmt.Sprintf("%d reps", reps))
+			if set.CompletedValue != nil {
+				setDescriptions = append(setDescriptions, fmt.Sprintf("%d reps", *set.CompletedValue))
+			}
+		case workout.ExerciseTypeTime:
+			// populated in Task 7
 		}
 	}
 

--- a/cmd/web/handler-exercise-info.go
+++ b/cmd/web/handler-exercise-info.go
@@ -122,7 +122,9 @@ func processEntryData(entry workout.ExerciseProgressEntry, typ workout.ExerciseT
 				setDescriptions = append(setDescriptions, fmt.Sprintf("%d reps", *set.CompletedValue))
 			}
 		case workout.ExerciseTypeTime:
-			// populated in Task 7
+			if set.CompletedValue != nil {
+				setDescriptions = append(setDescriptions, fmt.Sprintf("%ds", *set.CompletedValue))
+			}
 		}
 	}
 

--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -21,6 +21,9 @@ func formatTarget(exercise workout.Exercise, session workout.Session, target int
 	if exercise.IsTimed() {
 		return fmt.Sprintf("%ds", target)
 	}
+	// Hypertrophy display preserves the legacy 6-10 rep range UX. TargetValue
+	// is the single integer the planner emits (8); progression and storage use
+	// that, while the user sees the range.
 	if session.PeriodizationType == workout.PeriodizationHypertrophy {
 		return "6-10"
 	}

--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -263,8 +263,8 @@ func (app *application) recordSetCompletionWithWeight(
 	return true
 }
 
-// recordBodyweightSetCompletion handles parsing and persisting a bodyweight or time-based set
-// completion from form data.
+// recordBodyweightSetCompletion handles parsing and persisting a bodyweight set
+// completion from form data. Time-based sets go through recordTimedSetCompletion.
 func (app *application) recordBodyweightSetCompletion(
 	w http.ResponseWriter, r *http.Request,
 	params exerciseSetParams,

--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -14,10 +14,25 @@ import (
 	"github.com/myrjola/petrapp/internal/workout"
 )
 
+// formatTarget returns the display string for a set target.
+// For timed exercises it appends "s" (e.g. "30s").
+// For rep-based exercises it returns a plain integer or the hypertrophy range "6-10".
+func formatTarget(exercise workout.Exercise, session workout.Session, target int) string {
+	if exercise.IsTimed() {
+		return fmt.Sprintf("%ds", target)
+	}
+	if session.PeriodizationType == workout.PeriodizationHypertrophy {
+		return "6-10"
+	}
+	return strconv.Itoa(target)
+}
+
 type setDisplay struct {
-	Set    workout.Set
-	RepStr string // Formatted rep string (e.g. "8" or "6-8")
-	Number int    // 1-based set number for display.
+	Set          workout.Set
+	TargetStr    string // Pre-formatted target string (e.g. "5", "6-10", "30s").
+	CompletedStr string // Pre-formatted completed string, same unit as TargetStr.
+	Unit         string // "reps" or "seconds" — for input labels.
+	Number       int    // 1-based set number for display.
 }
 
 type exerciseSetTemplateData struct {
@@ -33,20 +48,28 @@ type exerciseSetTemplateData struct {
 	AbsCurrentWeight     float64                       // |CurrentSetTarget.WeightKg|, for assisted form input
 }
 
-func formatRepRange(minReps, maxReps int) string {
-	if minReps == maxReps {
-		return strconv.Itoa(minReps)
+func prepareSetsDisplay(exercise workout.Exercise, session workout.Session, sets []workout.Set) []setDisplay {
+	unit := "reps"
+	if exercise.IsTimed() {
+		unit = "seconds"
 	}
-	return fmt.Sprintf("%d-%d", minReps, maxReps)
-}
-
-func prepareSetsDisplay(sets []workout.Set) []setDisplay {
 	displays := make([]setDisplay, len(sets))
 	for i, set := range sets {
+		targetStr := formatTarget(exercise, session, set.TargetValue)
+		completedStr := ""
+		if set.CompletedValue != nil {
+			if exercise.IsTimed() {
+				completedStr = fmt.Sprintf("%ds", *set.CompletedValue)
+			} else {
+				completedStr = strconv.Itoa(*set.CompletedValue)
+			}
+		}
 		displays[i] = setDisplay{
-			Set:    set,
-			RepStr: formatRepRange(set.MinReps, set.MaxReps),
-			Number: i + 1,
+			Set:          set,
+			TargetStr:    targetStr,
+			CompletedStr: completedStr,
+			Unit:         unit,
+			Number:       i + 1,
 		}
 	}
 	return displays
@@ -54,7 +77,7 @@ func prepareSetsDisplay(sets []workout.Set) []setDisplay {
 
 func getFirstIncompleteIndex(sets []workout.Set) int {
 	for i, set := range sets {
-		if set.CompletedReps == nil {
+		if set.CompletedValue == nil {
 			return i
 		}
 	}
@@ -128,7 +151,7 @@ func (app *application) exerciseSetGET(w http.ResponseWriter, r *http.Request) {
 		BaseTemplateData:     newBaseTemplateData(r),
 		Date:                 date,
 		ExerciseSet:          exerciseSet,
-		SetsDisplay:          prepareSetsDisplay(exerciseSet.Sets),
+		SetsDisplay:          prepareSetsDisplay(exerciseSet.Exercise, session, exerciseSet.Sets),
 		FirstIncompleteIndex: getFirstIncompleteIndex(exerciseSet.Sets),
 		EditingIndex:         editingIndex,
 		IsEditing:            isEditing,
@@ -182,37 +205,6 @@ func findExerciseSetInSession(session *workout.Session, workoutExerciseID int) (
 	return workout.ExerciseSet{}, false //nolint:exhaustruct // zero value signals "not found".
 }
 
-// parseWeightAndReps extracts weight and reps from form data based on exercise type.
-func (app *application) parseWeightAndReps(r *http.Request, exercise workout.Exercise) (float64, int, error) {
-	var weight float64
-	if exercise.ExerciseType == workout.ExerciseTypeWeighted {
-		weightStr := r.PostForm.Get("weight")
-		if weightStr == "" {
-			return 0, 0, errors.New("weight not provided for weighted exercise")
-		}
-		// Replace comma with dot for decimal numbers.
-		weightStr = strings.Replace(weightStr, ",", ".", 1)
-
-		var err error
-		weight, err = strconv.ParseFloat(weightStr, 64)
-		if err != nil {
-			return 0, 0, fmt.Errorf("parse weight: %w", err)
-		}
-	}
-
-	repsStr := r.PostForm.Get("reps")
-	if repsStr == "" {
-		return 0, 0, errors.New("reps not provided")
-	}
-
-	reps, err := strconv.Atoi(repsStr)
-	if err != nil {
-		return 0, 0, fmt.Errorf("parse reps: %w", err)
-	}
-
-	return weight, reps, nil
-}
-
 // recordSetCompletionWithWeight handles parsing and persisting a weighted or assisted set completion from form data.
 func (app *application) recordSetCompletionWithWeight(
 	w http.ResponseWriter, r *http.Request,
@@ -256,6 +248,30 @@ func (app *application) recordSetCompletionWithWeight(
 	return true
 }
 
+// recordBodyweightSetCompletion handles parsing and persisting a bodyweight or time-based set
+// completion from form data.
+func (app *application) recordBodyweightSetCompletion(
+	w http.ResponseWriter, r *http.Request,
+	params exerciseSetParams,
+) bool {
+	completedValueStr := r.PostForm.Get("completed_value")
+	if completedValueStr == "" {
+		app.serverError(w, r, errors.New("completed_value not provided"))
+		return false
+	}
+	completedValue, err := strconv.Atoi(completedValueStr)
+	if err != nil {
+		app.serverError(w, r, fmt.Errorf("parse completed_value: %w", err))
+		return false
+	}
+	if err = app.workoutService.UpdateCompletedValue(
+		r.Context(), params.Date, params.WorkoutExerciseID, params.SetIndex, completedValue); err != nil {
+		app.serverError(w, r, fmt.Errorf("update completed value: %w", err))
+		return false
+	}
+	return true
+}
+
 func (app *application) exerciseSetUpdatePOST(w http.ResponseWriter, r *http.Request) {
 	params, err := app.parseExerciseSetURLParams(r)
 	if err != nil {
@@ -288,14 +304,7 @@ func (app *application) exerciseSetUpdatePOST(w http.ResponseWriter, r *http.Req
 			return
 		}
 	} else {
-		_, reps, parseErr := app.parseWeightAndReps(r, exercise)
-		if parseErr != nil {
-			app.serverError(w, r, parseErr)
-			return
-		}
-		if err = app.workoutService.UpdateCompletedReps(
-			r.Context(), params.Date, params.WorkoutExerciseID, params.SetIndex, reps); err != nil {
-			app.serverError(w, r, fmt.Errorf("update completed reps: %w", err))
+		if !app.recordBodyweightSetCompletion(w, r, params) {
 			return
 		}
 	}

--- a/cmd/web/handler-exerciseset.go
+++ b/cmd/web/handler-exerciseset.go
@@ -40,15 +40,16 @@ type setDisplay struct {
 
 type exerciseSetTemplateData struct {
 	BaseTemplateData
-	Date                 time.Time
-	ExerciseSet          workout.ExerciseSet
-	SetsDisplay          []setDisplay // Enhanced set data with formatted rep strings
-	FirstIncompleteIndex int
-	EditingIndex         int                           // Index of the set being edited
-	IsEditing            bool                          // Whether we're in edit mode
-	LastCompletedAt      *time.Time                    // Timestamp of most recently completed set
-	CurrentSetTarget     exerciseprogression.SetTarget // Recommended weight and reps from progression
-	AbsCurrentWeight     float64                       // |CurrentSetTarget.WeightKg|, for assisted form input
+	Date                  time.Time
+	ExerciseSet           workout.ExerciseSet
+	SetsDisplay           []setDisplay // Enhanced set data with formatted rep strings
+	FirstIncompleteIndex  int
+	EditingIndex          int                           // Index of the set being edited
+	IsEditing             bool                          // Whether we're in edit mode
+	LastCompletedAt       *time.Time                    // Timestamp of most recently completed set
+	CurrentSetTarget      exerciseprogression.SetTarget // Recommended weight and reps from progression
+	CurrentSetTimedTarget int                           // Recommended seconds for time_based exercises; 0 for others.
+	AbsCurrentWeight      float64                       // |CurrentSetTarget.WeightKg|, for assisted form input
 }
 
 func prepareSetsDisplay(exercise workout.Exercise, session workout.Session, sets []workout.Set) []setDisplay {
@@ -138,29 +139,40 @@ func (app *application) exerciseSetGET(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var currentSetTarget exerciseprogression.SetTarget
-	if exerciseSet.Exercise.ExerciseType == workout.ExerciseTypeWeighted ||
-		exerciseSet.Exercise.ExerciseType == workout.ExerciseTypeAssisted {
+	var currentSetTimedTarget int
+	switch exerciseSet.Exercise.ExerciseType {
+	case workout.ExerciseTypeWeighted, workout.ExerciseTypeAssisted:
 		progression, progressionErr := app.workoutService.BuildProgression(r.Context(), date, exerciseSet.Exercise.ID)
 		if progressionErr != nil {
 			app.serverError(w, r, progressionErr)
 			return
 		}
 		currentSetTarget = progression.CurrentSet()
+	case workout.ExerciseTypeTime:
+		progression, progressionErr := app.workoutService.BuildTimedProgression(r.Context(), date, exerciseSet.Exercise.ID)
+		if progressionErr != nil {
+			app.serverError(w, r, progressionErr)
+			return
+		}
+		currentSetTimedTarget = progression.CurrentSet().TargetSeconds
+	case workout.ExerciseTypeBodyweight:
+		// No progression engine for bodyweight — uses the stored target as-is.
 	}
 
 	absCurrentWeight := math.Abs(currentSetTarget.WeightKg)
 
 	data := exerciseSetTemplateData{
-		BaseTemplateData:     newBaseTemplateData(r),
-		Date:                 date,
-		ExerciseSet:          exerciseSet,
-		SetsDisplay:          prepareSetsDisplay(exerciseSet.Exercise, session, exerciseSet.Sets),
-		FirstIncompleteIndex: getFirstIncompleteIndex(exerciseSet.Sets),
-		EditingIndex:         editingIndex,
-		IsEditing:            isEditing,
-		LastCompletedAt:      getLastCompletedAt(exerciseSet.Sets),
-		CurrentSetTarget:     currentSetTarget,
-		AbsCurrentWeight:     absCurrentWeight,
+		BaseTemplateData:      newBaseTemplateData(r),
+		Date:                  date,
+		ExerciseSet:           exerciseSet,
+		SetsDisplay:           prepareSetsDisplay(exerciseSet.Exercise, session, exerciseSet.Sets),
+		FirstIncompleteIndex:  getFirstIncompleteIndex(exerciseSet.Sets),
+		EditingIndex:          editingIndex,
+		IsEditing:             isEditing,
+		LastCompletedAt:       getLastCompletedAt(exerciseSet.Sets),
+		CurrentSetTarget:      currentSetTarget,
+		CurrentSetTimedTarget: currentSetTimedTarget,
+		AbsCurrentWeight:      absCurrentWeight,
 	}
 
 	app.render(w, r, http.StatusOK, "exerciseset", data)
@@ -275,6 +287,40 @@ func (app *application) recordBodyweightSetCompletion(
 	return true
 }
 
+// recordTimedSetCompletion handles parsing and persisting a time-based set
+// completion: completed_seconds + signal.
+func (app *application) recordTimedSetCompletion(
+	w http.ResponseWriter, r *http.Request,
+	params exerciseSetParams,
+) bool {
+	completedValueStr := r.PostForm.Get("completed_value")
+	if completedValueStr == "" {
+		app.serverError(w, r, errors.New("completed_value not provided"))
+		return false
+	}
+	completedSeconds, err := strconv.Atoi(completedValueStr)
+	if err != nil {
+		app.serverError(w, r, fmt.Errorf("parse completed_value: %w", err))
+		return false
+	}
+
+	signal := workout.Signal(r.PostForm.Get("signal"))
+
+	if err = app.workoutService.RecordTimedSetCompletion(
+		r.Context(), params.Date, params.WorkoutExerciseID, params.SetIndex, signal, completedSeconds); err != nil {
+		app.serverError(w, r, fmt.Errorf("record timed set completion: %w", err))
+		return false
+	}
+
+	app.logger.LogAttrs(r.Context(), slog.LevelInfo, "recorded timed set completion",
+		slog.String("date", params.Date.Format("2006-01-02")),
+		slog.Int("workout_exercise_id", params.WorkoutExerciseID),
+		slog.Int("set_index", params.SetIndex),
+		slog.String("signal", string(signal)),
+		slog.Int("completed_seconds", completedSeconds))
+	return true
+}
+
 func (app *application) exerciseSetUpdatePOST(w http.ResponseWriter, r *http.Request) {
 	params, err := app.parseExerciseSetURLParams(r)
 	if err != nil {
@@ -301,12 +347,16 @@ func (app *application) exerciseSetUpdatePOST(w http.ResponseWriter, r *http.Req
 	}
 	exercise := exerciseSet.Exercise
 
-	if exercise.ExerciseType == workout.ExerciseTypeWeighted ||
-		exercise.ExerciseType == workout.ExerciseTypeAssisted {
+	switch exercise.ExerciseType {
+	case workout.ExerciseTypeWeighted, workout.ExerciseTypeAssisted:
 		if !app.recordSetCompletionWithWeight(w, r, params, exercise) {
 			return
 		}
-	} else {
+	case workout.ExerciseTypeTime:
+		if !app.recordTimedSetCompletion(w, r, params) {
+			return
+		}
+	case workout.ExerciseTypeBodyweight:
 		if !app.recordBodyweightSetCompletion(w, r, params) {
 			return
 		}

--- a/cmd/web/handler-exerciseset_test.go
+++ b/cmd/web/handler-exerciseset_test.go
@@ -674,7 +674,7 @@ func Test_application_workoutSwapExercise_sorts_by_similarity(t *testing.T) {
 		}
 		ex, ok := byID[id]
 		if !ok {
-			ex = workout.Exercise{
+			ex = workout.Exercise{ //nolint:exhaustruct // DefaultStartingSeconds intentionally omitted in test helper.
 				ID:                    id,
 				Name:                  name,
 				Category:              workout.Category(category),
@@ -803,8 +803,8 @@ func Test_application_exerciseSet_assisted_storage(t *testing.T) {
 	for setNum := 1; setNum <= 4; setNum++ {
 		if _, err = db.ExecContext(ctx,
 			`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-                weight_kg, min_reps, max_reps)
-             VALUES (?, ?, 0.0, 5, 5)`, slotID, setNum); err != nil {
+                weight_kg, target_value)
+             VALUES (?, ?, 0.0, 5)`, slotID, setNum); err != nil {
 			t.Fatalf("insert placeholder set %d: %v", setNum, err)
 		}
 	}

--- a/docs/superpowers/plans/2026-05-07-time-based-exercises.md
+++ b/docs/superpowers/plans/2026-05-07-time-based-exercises.md
@@ -1,0 +1,1598 @@
+# Time-Based Exercise Type Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a `time_based` exercise type so plank prescribes a duration (e.g., "hold 30s") instead of nonsense reps, and collapse the redundant `min_reps`/`max_reps` columns into a single `target_value` whose unit is derived from the parent exercise.
+
+**Architecture:** Adds a fourth value `time_based` to the `exercises.exercise_type` enum. Collapses `exercise_sets.min_reps`/`max_reps`/`completed_reps` into `target_value`/`completed_value`; the unit is reps for rep-based exercises and seconds for `time_based`. A parallel `TimedProgression` engine in `internal/exerciseprogression/` provides Signal-driven duration auto-regulation. A one-shot premigration translates legacy rows.
+
+**Tech Stack:** Go, SQLite (STRICT mode), html/template, declarative-schema migrator with premigration escape hatch.
+
+**Spec:** `specs/05-time-based-exercises.md`.
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/sqlite/premigrate.go` — one-shot exercise_sets premigration
+- `internal/exerciseprogression/timed_progression.go` — duration auto-regulation
+- `internal/exerciseprogression/timed_progression_test.go` — table-driven tests for the ladder
+
+**Modify:**
+- `internal/sqlite/schema.sql` — `time_based` enum, `default_starting_seconds`, collapsed `exercise_sets`
+- `internal/sqlite/fixtures.sql` — plank flips to `time_based`
+- `internal/sqlite/sqlite.go` — wire premigration between `connect` and `migrateTo`
+- `internal/sqlite/migrate_internal_test.go` — premigration test + legacy schema constant
+- `internal/workout/models.go` — `ExerciseTypeTime`, `Exercise.DefaultStartingSeconds`, `Exercise.IsTimed()`, `Set` field rename
+- `internal/workout/repository.go` / `repository-sessions.go` / `repository-exercises.go` — SQL select/insert with new columns
+- `internal/workout/service.go` — `IsTimed` branches, `UpdateCompletedValue`, `GetStartingSeconds`
+- `internal/workout/service_test.go` / `service_internal_test.go` — field references
+- `internal/weekplanner/weekplanner.go` — `PlannedSet.TargetValue`, `setsForPeriodization` simplification, `time_based` emission
+- `internal/weekplanner/weekplanner_internal_test.go` — field references
+- `cmd/web/handler-exerciseset.go` — `formatTarget` helper, `setDisplay`, `completed_value` form
+- `cmd/web/handler-exerciseset_test.go` — fixture SQL + assertions
+- `cmd/web/handler-exercise-info.go` — `processEntryData` `time_based` case
+- `cmd/web/handler-admin-exercises.go` — admin form for `time_based` + `default_starting_seconds`
+- `ui/templates/pages/exerciseset/sets-container.gohtml` — unit-agnostic rendering
+- `ui/templates/pages/workout/workout.gohtml` — same
+- `ui/templates/pages/admin/exercises*.gohtml` — admin form additions
+
+---
+
+## Task 1: TimedProgression engine
+
+Pure additive; no breaking changes. Implements the duration auto-regulation engine in isolation so it compiles and tests on its own before the schema refactor lands.
+
+**Files:**
+- Create: `internal/exerciseprogression/timed_progression.go`
+- Test: `internal/exerciseprogression/timed_progression_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/exerciseprogression/timed_progression_test.go`:
+
+```go
+package exerciseprogression_test
+
+import (
+	"testing"
+
+	"petrapp/internal/exerciseprogression"
+)
+
+func TestTimedProgressionCurrentSet(t *testing.T) {
+	t.Parallel()
+
+	type setup struct {
+		startingSeconds int
+		completed       []exerciseprogression.TimedSetResult
+	}
+	tests := []struct {
+		name string
+		in   setup
+		want int
+	}{
+		{
+			name: "first set returns starting seconds",
+			in:   setup{startingSeconds: 30, completed: nil},
+			want: 30,
+		},
+		{
+			name: "on_target keeps target",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 30, Signal: exerciseprogression.SignalOnTarget},
+			}},
+			want: 30,
+		},
+		{
+			name: "too_light under 60s bumps by 5",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 30, Signal: exerciseprogression.SignalTooLight},
+			}},
+			want: 35,
+		},
+		{
+			name: "too_light at 60s bumps by 10",
+			in: setup{startingSeconds: 60, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 60, Signal: exerciseprogression.SignalTooLight},
+			}},
+			want: 70,
+		},
+		{
+			name: "too_light at 120s bumps by 15",
+			in: setup{startingSeconds: 120, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 120, Signal: exerciseprogression.SignalTooLight},
+			}},
+			want: 135,
+		},
+		{
+			name: "too_heavy under 60s drops by 5",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 20, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			want: 25,
+		},
+		{
+			name: "too_heavy 10% drop snapped to 5s when larger than ladder step",
+			in: setup{startingSeconds: 90, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 70, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			// 10% of 90 = 9, snap5 = 10, ladder at 60-119s = 10 → max(10,10) = 10 → 80
+			want: 80,
+		},
+		{
+			name: "too_heavy floors at 5s",
+			in: setup{startingSeconds: 5, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 5, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			want: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := exerciseprogression.NewTimedFromHistory(
+				exerciseprogression.TimedConfig{StartingSeconds: tt.in.startingSeconds},
+				tt.in.completed,
+			)
+			got := p.CurrentSet().TargetSeconds
+			if got != tt.want {
+				t.Errorf("TargetSeconds = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimedProgressionRecordCompletion(t *testing.T) {
+	t.Parallel()
+
+	p := exerciseprogression.NewTimed(exerciseprogression.TimedConfig{StartingSeconds: 30})
+	if got := p.SetsCompleted(); got != 0 {
+		t.Fatalf("SetsCompleted before any record = %d, want 0", got)
+	}
+	p.RecordCompletion(exerciseprogression.TimedSetResult{
+		ActualSeconds: 30,
+		Signal:        exerciseprogression.SignalOnTarget,
+	})
+	if got := p.SetsCompleted(); got != 1 {
+		t.Errorf("SetsCompleted after one record = %d, want 1", got)
+	}
+	if got := p.CurrentSet().TargetSeconds; got != 30 {
+		t.Errorf("TargetSeconds after on_target = %d, want 30", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/exerciseprogression/ -run TestTimedProgression -v`
+Expected: build failure — `TimedProgression`, `NewTimed`, `NewTimedFromHistory`, `TimedConfig`, `TimedSetResult` undefined.
+
+- [ ] **Step 3: Implement TimedProgression**
+
+Create `internal/exerciseprogression/timed_progression.go`:
+
+```go
+package exerciseprogression
+
+import (
+	"fmt"
+	"math"
+)
+
+// TimedConfig is provided once when starting a timed exercise execution.
+type TimedConfig struct {
+	StartingSeconds int // seconds; caller-derived from history, may be user-overridden
+}
+
+// TimedSetTarget is what the package recommends for the upcoming hold.
+type TimedSetTarget struct {
+	TargetSeconds int
+}
+
+// TimedSetResult is recorded by the caller after the user completes a hold.
+type TimedSetResult struct {
+	ActualSeconds int
+	Signal        Signal
+}
+
+const (
+	timedSnapSeconds   = 5
+	timedFloorSeconds  = 5
+	timedDecrFraction  = 0.10
+	timedStepShort     = 5  // < 60s
+	timedStepMid       = 10 // 60–119s
+	timedStepLong      = 15 // ≥ 120s
+	timedMidThreshold  = 60
+	timedLongThreshold = 120
+)
+
+// TimedProgression manages duration progression for one timed exercise execution.
+type TimedProgression struct {
+	config    TimedConfig
+	completed []TimedSetResult
+}
+
+// NewTimed creates a TimedProgression for a new exercise execution.
+func NewTimed(c TimedConfig) *TimedProgression {
+	return &TimedProgression{config: c, completed: nil}
+}
+
+// NewTimedFromHistory reconstructs a TimedProgression from sets already completed in this session.
+func NewTimedFromHistory(c TimedConfig, completed []TimedSetResult) *TimedProgression {
+	p := NewTimed(c)
+	p.completed = make([]TimedSetResult, len(completed))
+	copy(p.completed, completed)
+	return p
+}
+
+// CurrentSet returns the recommended target for the next hold.
+func (p *TimedProgression) CurrentSet() TimedSetTarget {
+	if len(p.completed) == 0 {
+		return TimedSetTarget{TargetSeconds: p.config.StartingSeconds}
+	}
+	last := p.completed[len(p.completed)-1]
+	return TimedSetTarget{TargetSeconds: adjustedSeconds(last)}
+}
+
+// RecordCompletion records what actually happened and advances internal state.
+func (p *TimedProgression) RecordCompletion(r TimedSetResult) {
+	p.completed = append(p.completed, r)
+}
+
+// SetsCompleted returns the number of holds recorded so far.
+func (p *TimedProgression) SetsCompleted() int {
+	return len(p.completed)
+}
+
+func adjustedSeconds(last TimedSetResult) int {
+	step := timedIncrement(last.ActualSeconds)
+	switch last.Signal {
+	case SignalTooLight:
+		return snap5(last.ActualSeconds + step)
+	case SignalTooHeavy:
+		decrement := step
+		if pct := snap5(int(math.Round(float64(last.ActualSeconds) * timedDecrFraction))); pct > decrement {
+			decrement = pct
+		}
+		next := last.ActualSeconds - decrement
+		if next < timedFloorSeconds {
+			next = timedFloorSeconds
+		}
+		return snap5(next)
+	case SignalOnTarget:
+		return last.ActualSeconds
+	case SignalUnknown:
+		panic("exerciseprogression: TimedSetResult must not use SignalUnknown")
+	}
+	panic(fmt.Sprintf("exerciseprogression: unhandled Signal %d", last.Signal))
+}
+
+func timedIncrement(current int) int {
+	switch {
+	case current < timedMidThreshold:
+		return timedStepShort
+	case current < timedLongThreshold:
+		return timedStepMid
+	default:
+		return timedStepLong
+	}
+}
+
+func snap5(seconds int) int {
+	return int(math.Round(float64(seconds)/float64(timedSnapSeconds))) * timedSnapSeconds
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/exerciseprogression/ -run TestTimedProgression -v`
+Expected: PASS for all sub-tests.
+
+- [ ] **Step 5: Run full package tests**
+
+Run: `go test ./internal/exerciseprogression/...`
+Expected: all existing rep-based tests still PASS; new timed tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/exerciseprogression/timed_progression.go internal/exerciseprogression/timed_progression_test.go
+git commit -m "$(cat <<'EOF'
+Add TimedProgression engine for duration auto-regulation
+
+Mirrors the weighted Progression but bumps seconds with a step ladder
+(5/10/15s under/at/over 60s/120s) and a 10% decrement floor on
+too_heavy. Targets snapped to multiples of 5s and floored at 5s.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Schema collapse + premigration + Go layer rename
+
+This is the dominant refactor: schema, premigration, domain model, repository, service, planner, handlers, templates, and tests all move from `min_reps`/`max_reps`/`completed_reps` to `target_value`/`completed_value` in lockstep so the build never breaks. Adds the `time_based` enum value and `default_starting_seconds` column on `exercises` so the next tasks have somewhere to land.
+
+**Files:**
+- Modify: `internal/sqlite/schema.sql`
+- Create: `internal/sqlite/premigrate.go`
+- Modify: `internal/sqlite/sqlite.go`
+- Modify: `internal/sqlite/migrate_internal_test.go`
+- Modify: `internal/workout/models.go`
+- Modify: `internal/workout/repository-sessions.go`
+- Modify: `internal/workout/repository-exercises.go`
+- Modify: `internal/workout/service.go`
+- Modify: `internal/workout/service_test.go`, `internal/workout/service_internal_test.go`
+- Modify: `internal/weekplanner/weekplanner.go`
+- Modify: `internal/weekplanner/weekplanner_internal_test.go`
+- Modify: `cmd/web/handler-exerciseset.go`
+- Modify: `cmd/web/handler-exerciseset_test.go`
+- Modify: `cmd/web/handler-exercise-info.go`
+- Modify: `ui/templates/pages/exerciseset/sets-container.gohtml`
+- Modify: `ui/templates/pages/workout/workout.gohtml`
+
+This task is structured as phases. Each phase is a coherent change; commit only at the end after the full build + test passes.
+
+### Phase 2A: Schema + premigration
+
+- [ ] **Step 2A.1: Modify `internal/sqlite/schema.sql` — exercises and exercise_sets**
+
+Replace the `exercises` table definition with:
+
+```sql
+CREATE TABLE exercises
+(
+    id                       INTEGER PRIMARY KEY,
+    name                     TEXT NOT NULL UNIQUE CHECK (LENGTH(name) < 124),
+    category                 TEXT NOT NULL CHECK (category IN ('full_body', 'upper', 'lower')),
+    exercise_type            TEXT NOT NULL DEFAULT 'weighted'
+                             CHECK (exercise_type IN ('weighted', 'bodyweight', 'assisted', 'time_based')),
+    description_markdown     TEXT NOT NULL DEFAULT '' CHECK (LENGTH(description_markdown) < 20000),
+    default_starting_seconds INTEGER CHECK (default_starting_seconds IS NULL OR default_starting_seconds > 0),
+    CHECK (exercise_type <> 'time_based' OR default_starting_seconds IS NOT NULL)
+) STRICT;
+```
+
+Replace the `exercise_sets` table with the collapsed shape:
+
+```sql
+CREATE TABLE exercise_sets
+(
+    workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
+    set_number          INTEGER NOT NULL CHECK (set_number > 0),
+    weight_kg           REAL,
+    target_value        INTEGER NOT NULL CHECK (target_value > 0),
+    completed_value     INTEGER CHECK (completed_value IS NULL OR completed_value >= 0),
+    completed_at        TEXT CHECK (completed_at IS NULL OR
+                                    STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),
+    signal              TEXT CHECK (signal IS NULL OR signal IN ('too_heavy', 'on_target', 'too_light')),
+
+    PRIMARY KEY (workout_exercise_id, set_number)
+) WITHOUT ROWID, STRICT;
+```
+
+- [ ] **Step 2A.2: Create premigration**
+
+Create `internal/sqlite/premigrate.go`:
+
+```go
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// preMigrateExerciseSetTarget rewrites the legacy exercise_sets shape
+// (min_reps/max_reps/completed_reps) into the collapsed target_value/
+// completed_value shape, dropping historical Plank rows whose reps would be
+// nonsensical to reinterpret as seconds. Idempotent and safe on a fresh DB.
+//
+// Delete this file, its call site in NewDatabase, the test in
+// migrate_internal_test.go, and the legacy schema constant once it has run
+// in production.
+func (db *Database) preMigrateExerciseSetTarget(ctx context.Context) error {
+	// Already migrated? (target_value column exists)
+	var hasTarget int
+	err := db.ReadWrite.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('exercise_sets') WHERE name = 'target_value'`,
+	).Scan(&hasTarget)
+	if err != nil {
+		return fmt.Errorf("pragma_table_info exercise_sets: %w", err)
+	}
+	if hasTarget > 0 {
+		return nil
+	}
+
+	// Fresh DB? (no exercise_sets table at all)
+	var hasTable int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='exercise_sets'`,
+	).Scan(&hasTable)
+	if err != nil {
+		return fmt.Errorf("sqlite_master exercise_sets: %w", err)
+	}
+	if hasTable == 0 {
+		return nil
+	}
+
+	if _, err = db.ReadWrite.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("disable foreign keys: %w", err)
+	}
+
+	tx, err := db.ReadWrite.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+				err = fmt.Errorf("%w; rollback: %w", err, rbErr)
+			}
+		}
+	}()
+
+	stmts := []string{
+		`CREATE TABLE exercise_sets_new (
+			workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
+			set_number          INTEGER NOT NULL CHECK (set_number > 0),
+			weight_kg           REAL,
+			target_value        INTEGER NOT NULL CHECK (target_value > 0),
+			completed_value     INTEGER CHECK (completed_value IS NULL OR completed_value >= 0),
+			completed_at        TEXT CHECK (completed_at IS NULL OR
+			                                STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),
+			signal              TEXT CHECK (signal IS NULL OR signal IN ('too_heavy', 'on_target', 'too_light')),
+			PRIMARY KEY (workout_exercise_id, set_number)
+		) WITHOUT ROWID, STRICT`,
+		`INSERT INTO exercise_sets_new
+			(workout_exercise_id, set_number, weight_kg, target_value,
+			 completed_value, completed_at, signal)
+		 SELECT s.workout_exercise_id, s.set_number, s.weight_kg,
+		        s.max_reps, s.completed_reps, s.completed_at, s.signal
+		   FROM exercise_sets s
+		   JOIN workout_exercise wx ON wx.id = s.workout_exercise_id
+		   JOIN exercises e         ON e.id = wx.exercise_id
+		  WHERE e.name <> 'Plank'`,
+		`DROP TABLE exercise_sets`,
+		`ALTER TABLE exercise_sets_new RENAME TO exercise_sets`,
+	}
+	for _, q := range stmts {
+		if _, err = tx.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("premigrate exercise_sets: %w", err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2A.3: Wire premigration into `NewDatabase`**
+
+In `internal/sqlite/sqlite.go`, between the `connect` call (line 51) and the `migrateTo` call (line 55), add:
+
+```go
+	if err = db.preMigrateExerciseSetTarget(ctx); err != nil {
+		return nil, fmt.Errorf("preMigrateExerciseSetTarget: %w", err)
+	}
+```
+
+So that block becomes:
+
+```go
+	if db, err = connect(ctx, url, logger); err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+
+	if err = db.preMigrateExerciseSetTarget(ctx); err != nil {
+		return nil, fmt.Errorf("preMigrateExerciseSetTarget: %w", err)
+	}
+
+	if err = db.migrateTo(ctx, schemaDefinition); err != nil {
+		return nil, fmt.Errorf("migrateTo: %w", err)
+	}
+```
+
+- [ ] **Step 2A.4: Write premigration test**
+
+In `internal/sqlite/migrate_internal_test.go`, add the legacy schema constant and the test. Find an open spot near other premigration tests if any exist; otherwise append:
+
+```go
+const legacyExerciseSetsSchema = `
+CREATE TABLE workout_sessions (
+	user_id            INTEGER NOT NULL,
+	workout_date       TEXT    NOT NULL,
+	difficulty_rating  INTEGER,
+	started_at         TEXT,
+	completed_at       TEXT,
+	periodization_type TEXT NOT NULL DEFAULT 'strength',
+	PRIMARY KEY (user_id, workout_date)
+) WITHOUT ROWID, STRICT;
+
+CREATE TABLE workout_exercise (
+	id                  INTEGER PRIMARY KEY,
+	workout_user_id     INTEGER NOT NULL,
+	workout_date        TEXT    NOT NULL,
+	exercise_id         INTEGER NOT NULL,
+	warmup_completed_at TEXT
+) STRICT;
+
+CREATE TABLE exercises (
+	id                   INTEGER PRIMARY KEY,
+	name                 TEXT NOT NULL UNIQUE,
+	category             TEXT NOT NULL,
+	exercise_type        TEXT NOT NULL DEFAULT 'weighted',
+	description_markdown TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE TABLE exercise_sets (
+	workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
+	set_number          INTEGER NOT NULL CHECK (set_number > 0),
+	weight_kg           REAL,
+	min_reps            INTEGER NOT NULL CHECK (min_reps > 0),
+	max_reps            INTEGER NOT NULL CHECK (max_reps >= min_reps),
+	completed_reps      INTEGER CHECK (completed_reps IS NULL OR completed_reps >= 0),
+	completed_at        TEXT,
+	signal              TEXT,
+	PRIMARY KEY (workout_exercise_id, set_number)
+) WITHOUT ROWID, STRICT;
+`
+
+func TestPreMigrateExerciseSetTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	db, err := connect(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err := db.ReadWrite.ExecContext(ctx, legacyExerciseSetsSchema); err != nil {
+		t.Fatalf("apply legacy schema: %v", err)
+	}
+	seed := `
+INSERT INTO exercises (id, name, category, exercise_type) VALUES
+	(1, 'Bench Press', 'upper', 'weighted'),
+	(2, 'Plank',       'upper', 'bodyweight');
+INSERT INTO workout_sessions (user_id, workout_date, periodization_type) VALUES
+	(1, '2026-04-01', 'hypertrophy');
+INSERT INTO workout_exercise (id, workout_user_id, workout_date, exercise_id) VALUES
+	(10, 1, '2026-04-01', 1),
+	(11, 1, '2026-04-01', 2);
+INSERT INTO exercise_sets (workout_exercise_id, set_number, weight_kg, min_reps, max_reps, completed_reps, signal) VALUES
+	(10, 1, 60.0, 6, 10, 8, 'on_target'),
+	(11, 1, NULL, 5, 5, 5, 'on_target');
+`
+	if _, err := db.ReadWrite.ExecContext(ctx, seed); err != nil {
+		t.Fatalf("seed legacy data: %v", err)
+	}
+
+	if err := db.preMigrateExerciseSetTarget(ctx); err != nil {
+		t.Fatalf("preMigrate: %v", err)
+	}
+
+	// Bench row: target_value = max_reps = 10, completed_value = 8.
+	var target, completed int
+	if err := db.ReadWrite.QueryRowContext(ctx,
+		`SELECT target_value, completed_value FROM exercise_sets WHERE workout_exercise_id = 10`,
+	).Scan(&target, &completed); err != nil {
+		t.Fatalf("read bench row: %v", err)
+	}
+	if target != 10 || completed != 8 {
+		t.Errorf("bench row: target=%d completed=%d, want 10 and 8", target, completed)
+	}
+
+	// Plank row dropped.
+	var plankCount int
+	if err := db.ReadWrite.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM exercise_sets WHERE workout_exercise_id = 11`,
+	).Scan(&plankCount); err != nil {
+		t.Fatalf("count plank rows: %v", err)
+	}
+	if plankCount != 0 {
+		t.Errorf("plank rows after migration = %d, want 0", plankCount)
+	}
+
+	// Idempotent: second call is a no-op and does not error.
+	if err := db.preMigrateExerciseSetTarget(ctx); err != nil {
+		t.Fatalf("preMigrate idempotent call: %v", err)
+	}
+
+	// Declarative migrator must accept the new schema as no-op for exercise_sets.
+	if err := db.migrateTo(ctx, schemaDefinition); err != nil {
+		t.Fatalf("migrateTo after premigration: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2A.5: Run premigration test**
+
+Run: `go test ./internal/sqlite/ -run TestPreMigrateExerciseSetTarget -v`
+Expected: PASS.
+
+### Phase 2B: Domain model + repository
+
+- [ ] **Step 2B.1: Update `internal/workout/models.go`**
+
+Add the `ExerciseTypeTime` constant and `IsTimed()` helper, add `DefaultStartingSeconds` to `Exercise`, and replace the rep fields on `Set` with `TargetValue`/`CompletedValue`.
+
+```go
+const (
+    ExerciseTypeWeighted   ExerciseType = "weighted"
+    ExerciseTypeBodyweight ExerciseType = "bodyweight"
+    ExerciseTypeAssisted   ExerciseType = "assisted"
+    ExerciseTypeTime       ExerciseType = "time_based"
+)
+
+type Exercise struct {
+    ID                     int          `json:"id"`
+    Name                   string       `json:"name"`
+    Category               Category     `json:"category"`
+    ExerciseType           ExerciseType `json:"exercise_type"`
+    DescriptionMarkdown    string       `json:"description_markdown"`
+    PrimaryMuscleGroups    []string     `json:"primary_muscle_groups"`
+    SecondaryMuscleGroups  []string     `json:"secondary_muscle_groups"`
+    DefaultStartingSeconds *int         `json:"default_starting_seconds,omitempty"`
+}
+
+func (e Exercise) IsTimed() bool { return e.ExerciseType == ExerciseTypeTime }
+
+type Set struct {
+    WeightKg       *float64
+    TargetValue    int
+    CompletedValue *int
+    CompletedAt    *time.Time
+    Signal         *Signal
+}
+```
+
+Update `exerciseJSONSchema.MarshalJSON` to include `'time_based'` in the `exercise_type` enum and add the optional `default_starting_seconds` property.
+
+- [ ] **Step 2B.2: Update `internal/workout/repository-sessions.go`**
+
+Replace each occurrence of `min_reps`, `max_reps`, `completed_reps` in SQL strings with `target_value` and `completed_value` as appropriate. Update the row scanner near line 597 to scan `target_value` and `completed_value`. Update INSERT around line 722 to insert into the new columns. Update the `loadExerciseSets` SELECT around line 327. Update `ListSetsForExerciseSince`'s SELECT around line 473. Update `GetLatestStartingWeightBefore`'s WHERE at line 567 to use `completed_value IS NOT NULL`.
+
+Also update the row struct around line 408–417 to scan into `set.TargetValue` and `set.CompletedValue` directly.
+
+Concretely, the scanner block near line 597 becomes:
+
+```go
+if err := rows.Scan(&workoutDateStr, &set.WeightKg, &set.TargetValue,
+    &set.CompletedValue, &completedAtStr, &warmupCompletedAtStr, &signalStr); err != nil {
+    return "", Set{}, sql.NullString{}, fmt.Errorf("scan exercise set row: %w", err)
+}
+```
+
+The INSERT around line 722 becomes:
+
+```go
+INSERT INTO exercise_sets (
+    workout_exercise_id, set_number,
+    weight_kg, target_value, completed_value, completed_at, signal
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+```
+
+And the parameterised values change to `set.WeightKg, set.TargetValue, set.CompletedValue, completedAtStr, signalValue`.
+
+- [ ] **Step 2B.3: Update `internal/workout/repository-exercises.go` to load `default_starting_seconds`**
+
+Add `default_starting_seconds` to every `SELECT` from `exercises`, scan into `*int`, and assign to the `Exercise` struct.
+
+### Phase 2C: Service + planner
+
+- [ ] **Step 2C.1: Update `internal/workout/service.go`**
+
+Replace every `MinReps`/`MaxReps`/`CompletedReps` reference with `TargetValue`/`CompletedValue`. Specifically:
+
+- Line ~198–200 (set construction in workout-generation path): `MinReps`/`MaxReps` → `TargetValue: planSet.TargetValue`
+- Line ~361–408 (`UpdateCompletedReps`): rename method to `UpdateCompletedValue`, parameter `completedReps int` → `completedValue int`, field assignments use `CompletedValue`.
+- Line ~531 (signal-conditional read): `set.CompletedReps != nil` → `set.CompletedValue != nil`.
+- Line ~618–635 (history reconstruction for Progression): `set.CompletedReps` → `set.CompletedValue`; `ActualReps: *set.CompletedReps` → `ActualReps: *set.CompletedValue` (the rep-based Progression engine still calls it `ActualReps`; this is a unit alias on the rep-based path).
+- Line ~882–904 (set-shape duplication for swap path): `MinReps`/`MaxReps` → `TargetValue`; `CompletedReps: nil` → `CompletedValue: nil`.
+- Line ~967–1019 (default constants and placeholder generation): `defaultMinReps`/`defaultMaxReps` collapse into `defaultTargetValue = 8`; placeholder set construction uses `TargetValue: defaultTargetValue`.
+
+- [ ] **Step 2C.2: Update `internal/workout/service_test.go` and `internal/workout/service_internal_test.go`**
+
+Replace every `MinReps`, `MaxReps`, `CompletedReps` field reference with `TargetValue` and `CompletedValue`. For tests that use `MinReps: 8, MaxReps: 12`, set `TargetValue: 12` (matching the migration rule of taking the top of the range).
+
+- [ ] **Step 2C.3: Update `internal/weekplanner/weekplanner.go`**
+
+Replace `PlannedSet`'s `MinReps`/`MaxReps` (lines 141–142) with a single field:
+
+```go
+type PlannedSet struct {
+    TargetValue int
+}
+```
+
+Replace `setsForPeriodization` (line 296) — change signature from `(int, int)` to a single `int`:
+
+```go
+func setsForPeriodization(p PeriodizationType) int {
+    if p == PeriodizationStrength {
+        return repsStrength
+    }
+    return repsHypertrophy
+}
+```
+
+(introducing `repsStrength = 5` and `repsHypertrophy = 8` constants if needed; pull from `internal/exerciseprogression/progression.go` if importable cleanly, otherwise duplicate the literals — they're a single line.)
+
+Update line 424 to:
+
+```go
+sets[i] = PlannedSet{TargetValue: targetValue}
+```
+
+- [ ] **Step 2C.4: Update `internal/weekplanner/weekplanner_internal_test.go`**
+
+Replace `s.MinReps != minRepsStrength || s.MaxReps != maxRepsStrength` (line 287) with a check against `TargetValue`. For example:
+
+```go
+if s.TargetValue != 5 {
+    t.Errorf("expected TargetValue 5, got %d", s.TargetValue)
+}
+```
+
+### Phase 2D: Handlers + templates
+
+- [ ] **Step 2D.1: Update `cmd/web/handler-exerciseset.go`**
+
+Replace `formatRepRange` (line 36) with `formatTarget`:
+
+```go
+func formatTarget(exercise workout.Exercise, session workout.Session, target int) string {
+    if exercise.IsTimed() {
+        return fmt.Sprintf("%ds", target)
+    }
+    if session.PeriodizationType == workout.PeriodizationHypertrophy {
+        return "6-10"
+    }
+    return strconv.Itoa(target)
+}
+```
+
+Update `setDisplay` (line ~26–33) to expose pre-formatted strings:
+
+```go
+type setDisplay struct {
+    Set            workout.Set
+    TargetStr      string
+    CompletedStr   string
+    Unit           string // "reps" or "seconds" — for input labels
+    Number         int
+    // ...preserve other existing fields...
+}
+```
+
+Update `prepareSetsDisplay` to construct `TargetStr`/`CompletedStr`/`Unit` from the set + parent exercise + session.
+
+Update the form-handling endpoint near line 296:
+
+- Form field name: `completed_reps` → `completed_value`.
+- Service call: `app.workoutService.UpdateCompletedReps(...)` → `app.workoutService.UpdateCompletedValue(...)`.
+
+- [ ] **Step 2D.2: Update `cmd/web/handler-exerciseset_test.go`**
+
+Replace the test SQL fixture `weight_kg, min_reps, max_reps` (line 806) with `weight_kg, target_value`. Update assertions on rep fields to assert on `TargetValue` / `CompletedValue`.
+
+- [ ] **Step 2D.3: Update `cmd/web/handler-exercise-info.go`**
+
+In `processEntryData` (line 108):
+
+```go
+case workout.ExerciseTypeBodyweight:
+    setDescriptions = append(setDescriptions, fmt.Sprintf("%d reps", *set.CompletedValue))
+```
+
+(Also update the weighted/assisted branch at line 117 to use `*set.CompletedValue` instead of `reps`. Remove the `reps := *set.CompletedReps` line at line 112.)
+
+The `time_based` case is added in Task 7 — leave a `default` panic for now or add the empty case to the switch (Go's exhaustive-enum check will require it):
+
+```go
+case workout.ExerciseTypeTime:
+    // populated in Task 7
+```
+
+- [ ] **Step 2D.4: Update templates**
+
+In `ui/templates/pages/exerciseset/sets-container.gohtml`: every `$set.CompletedReps` becomes `$set.CompletedValue`. Where the template renders "X reps" by reading the model directly, switch to reading the pre-formatted string from the `setDisplay` struct (e.g., `{{ .CompletedStr }}`).
+
+In `ui/templates/pages/workout/workout.gohtml`: same — `.CompletedReps` → `.CompletedValue`.
+
+Search for any remaining template references with: `grep -rn "CompletedReps\|MinReps\|MaxReps" ui/templates/`. There should be zero matches after the edits.
+
+Also rename the form input name in the input element from `completed_reps` to `completed_value`.
+
+### Phase 2E: Build, test, commit
+
+- [ ] **Step 2E.1: Build the project**
+
+Run: `go build ./...`
+Expected: clean build with no errors.
+
+- [ ] **Step 2E.2: Run lint with auto-fix**
+
+Run: `make lint-fix`
+Expected: clean exit. Address any remaining complaints (typically govet shadow can be fixed by reusing `err`).
+
+- [ ] **Step 2E.3: Run tests**
+
+Run: `make test`
+Expected: PASS for all packages.
+
+- [ ] **Step 2E.4: Commit**
+
+```bash
+git add internal/sqlite internal/workout internal/weekplanner internal/exerciseprogression cmd/web ui/templates
+git commit -m "$(cat <<'EOF'
+Collapse exercise_sets min/max reps into single target_value
+
+Adds a one-shot premigration that rewrites legacy exercise_sets rows
+into the new shape (target_value = max_reps, completed_value =
+completed_reps), dropping historical Plank rows that would otherwise be
+mis-rendered as seconds. Renames Set fields, planner emission,
+repository SQL, handlers, and templates to match.
+
+Also adds 'time_based' to the exercise_type enum and a
+default_starting_seconds column on exercises so the next changes have
+somewhere to land. Plank fixture itself is updated in a follow-up
+commit.
+
+Delete internal/sqlite/premigrate.go, the call site in NewDatabase, and
+the test/legacy-schema constant in migrate_internal_test.go after this
+ships to production.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Service `GetStartingSeconds` + repository accessor
+
+Adds the cross-session derivation for time-based exercises. Mirrors `GetStartingWeight` shape.
+
+**Files:**
+- Modify: `internal/workout/repository-sessions.go`
+- Modify: `internal/workout/service.go`
+- Modify: `internal/workout/service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/workout/service_test.go`, add:
+
+```go
+func Test_GetStartingSeconds(t *testing.T) {
+    t.Parallel()
+
+    ctx, svc, db := setupServiceTest(t) // existing helper used by Test_GetStartingWeight
+    defer db.Close()
+
+    today := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+
+    // Insert a time_based exercise with default_starting_seconds = 30.
+    if _, err := db.ReadWrite.ExecContext(ctx, `
+        INSERT INTO exercises (id, name, category, exercise_type, default_starting_seconds)
+        VALUES (99, 'Plank Test', 'upper', 'time_based', 30)
+    `); err != nil {
+        t.Fatalf("seed exercise: %v", err)
+    }
+
+    // No history → falls back to default.
+    got, err := svc.GetStartingSeconds(ctx, 99, today)
+    if err != nil {
+        t.Fatalf("GetStartingSeconds no history: %v", err)
+    }
+    if got != 30 {
+        t.Errorf("no history: got %d, want 30 (default)", got)
+    }
+
+    // Seed a successful prior session: completed 40s, on_target.
+    seedTimedSet(t, db, ctx, /* userID */ 1, /* exerciseID */ 99,
+        time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC), 40, "on_target")
+
+    got, err = svc.GetStartingSeconds(ctx, 99, today)
+    if err != nil {
+        t.Fatalf("GetStartingSeconds with history: %v", err)
+    }
+    if got != 40 {
+        t.Errorf("with history: got %d, want 40", got)
+    }
+
+    // Seed a too_heavy set today (after `today`'s date cutoff is exclusive,
+    // earlier date with too_heavy should be skipped).
+    seedTimedSet(t, db, ctx, 1, 99,
+        time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC), 50, "too_heavy")
+
+    got, err = svc.GetStartingSeconds(ctx, 99, today)
+    if err != nil {
+        t.Fatalf("GetStartingSeconds skipping too_heavy: %v", err)
+    }
+    if got != 40 {
+        t.Errorf("too_heavy filter: got %d, want 40 (older successful set)", got)
+    }
+}
+
+// seedTimedSet inserts a single completed time-based set for the given
+// (user, exercise, date). Helper keeps the test body short.
+func seedTimedSet(t *testing.T, db *sqlite.Database, ctx context.Context,
+    userID, exerciseID int, date time.Time, completed int, signal string,
+) {
+    t.Helper()
+    dateStr := date.Format("2006-01-02")
+    if _, err := db.ReadWrite.ExecContext(ctx, `
+        INSERT INTO workout_sessions (user_id, workout_date, periodization_type)
+        VALUES (?, ?, 'strength')
+        ON CONFLICT DO NOTHING
+    `, userID, dateStr); err != nil {
+        t.Fatalf("seed session: %v", err)
+    }
+    var weID int
+    if err := db.ReadWrite.QueryRowContext(ctx, `
+        INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id)
+        VALUES (?, ?, ?) RETURNING id
+    `, userID, dateStr, exerciseID).Scan(&weID); err != nil {
+        t.Fatalf("seed workout_exercise: %v", err)
+    }
+    if _, err := db.ReadWrite.ExecContext(ctx, `
+        INSERT INTO exercise_sets
+            (workout_exercise_id, set_number, target_value, completed_value, completed_at, signal)
+        VALUES (?, 1, ?, ?, '2026-05-05T12:00:00.000Z', ?)
+    `, weID, completed, completed, signal); err != nil {
+        t.Fatalf("seed exercise_set: %v", err)
+    }
+}
+```
+
+(If `setupServiceTest` doesn't exist as a helper today, follow the existing `Test_GetStartingWeight` setup pattern in `service_test.go` to wire `ctx`, `svc`, and `db`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/workout/ -run Test_GetStartingSeconds -v`
+Expected: FAIL — `svc.GetStartingSeconds` undefined.
+
+- [ ] **Step 3: Add repository accessor**
+
+In `internal/workout/repository-sessions.go`, near `GetLatestStartingWeightBefore`:
+
+```go
+// GetLatestSuccessfulSecondsBefore returns the completed_value of the latest
+// successful set for the given time-based exercise from a session strictly
+// before beforeDate. A set is "successful" when completed_value IS NOT NULL
+// and signal is 'on_target' or 'too_light'. Returns 0 when no successful
+// history exists.
+func (r *sqliteSessionRepository) GetLatestSuccessfulSecondsBefore(
+    ctx context.Context,
+    exerciseID int,
+    beforeDate time.Time,
+) (int, error) {
+    userID := contexthelpers.AuthenticatedUserID(ctx)
+    var seconds int
+    err := r.db.ReadOnly.QueryRowContext(ctx, `
+        SELECT es.completed_value
+        FROM exercise_sets es
+        JOIN workout_exercise we ON we.id = es.workout_exercise_id
+        WHERE we.workout_user_id = ?
+          AND we.exercise_id = ?
+          AND we.workout_date < ?
+          AND es.completed_value IS NOT NULL
+          AND es.signal IN ('on_target', 'too_light')
+        ORDER BY we.workout_date DESC, es.set_number DESC
+        LIMIT 1`,
+        userID, exerciseID, formatDate(beforeDate)).Scan(&seconds)
+    if err != nil {
+        if errors.Is(err, sql.ErrNoRows) {
+            return 0, nil
+        }
+        return 0, fmt.Errorf("query latest successful seconds: %w", err)
+    }
+    return seconds, nil
+}
+```
+
+Add the method to the `sessionRepository` interface (near the other methods).
+
+- [ ] **Step 4: Add service method**
+
+In `internal/workout/service.go`, near `GetStartingWeight`:
+
+```go
+// GetStartingSeconds returns the seconds target to seed a new session for
+// the given time-based exercise. Pulls the latest successful set's
+// completed_value from sessions strictly before beforeDate; falls back to
+// exercise.DefaultStartingSeconds when no successful history exists. Returns
+// an error if the exercise is not time_based or if the lookup fails.
+func (s *Service) GetStartingSeconds(
+    ctx context.Context,
+    exerciseID int,
+    beforeDate time.Time,
+) (int, error) {
+    exercise, err := s.repo.exercises.Get(ctx, exerciseID)
+    if err != nil {
+        return 0, fmt.Errorf("get exercise: %w", err)
+    }
+    if !exercise.IsTimed() {
+        return 0, fmt.Errorf("exercise %d is not time_based", exerciseID)
+    }
+    seconds, err := s.repo.sessions.GetLatestSuccessfulSecondsBefore(ctx, exerciseID, beforeDate)
+    if err != nil {
+        return 0, fmt.Errorf("get latest successful seconds: %w", err)
+    }
+    if seconds > 0 {
+        return seconds, nil
+    }
+    if exercise.DefaultStartingSeconds == nil {
+        return 0, fmt.Errorf("time_based exercise %d has no default_starting_seconds", exerciseID)
+    }
+    return *exercise.DefaultStartingSeconds, nil
+}
+```
+
+(If `s.repo.exercises.Get` doesn't exist with that exact signature, mirror the existing read pattern used elsewhere in the service.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/workout/ -run Test_GetStartingSeconds -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run full package tests**
+
+Run: `go test ./internal/workout/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/workout
+git commit -m "$(cat <<'EOF'
+Add GetStartingSeconds for time-based exercise progression
+
+Mirrors GetStartingWeight: pulls the latest successful set's
+completed_value from sessions strictly before the cutoff date, filtered
+to signal IN ('on_target', 'too_light'). Falls back to
+exercise.DefaultStartingSeconds when no qualifying history exists.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: BuildProgression `IsTimed` branch
+
+Wires `TimedProgression` into the service so the rest of the app can ask for the current target regardless of unit. Mirrors the existing `BuildProgression` shape with a parallel `BuildTimedProgression`.
+
+**Files:**
+- Modify: `internal/workout/service.go`
+- Modify: `internal/workout/service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/workout/service_test.go`:
+
+```go
+func Test_BuildTimedProgression(t *testing.T) {
+    t.Parallel()
+
+    ctx, svc, db := setupServiceTest(t)
+    defer db.Close()
+
+    today := time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC)
+
+    if _, err := db.ReadWrite.ExecContext(ctx, `
+        INSERT INTO exercises (id, name, category, exercise_type, default_starting_seconds)
+        VALUES (99, 'Plank Test', 'upper', 'time_based', 30);
+        INSERT INTO workout_sessions (user_id, workout_date, periodization_type)
+        VALUES (1, '2026-05-07', 'strength');
+    `); err != nil {
+        t.Fatalf("seed: %v", err)
+    }
+
+    progression, err := svc.BuildTimedProgression(ctx, today, 99)
+    if err != nil {
+        t.Fatalf("BuildTimedProgression: %v", err)
+    }
+    if got := progression.CurrentSet().TargetSeconds; got != 30 {
+        t.Errorf("CurrentSet().TargetSeconds = %d, want 30 (default)", got)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/workout/ -run Test_BuildTimedProgression -v`
+Expected: FAIL — `BuildTimedProgression` undefined.
+
+- [ ] **Step 3: Implement the service method**
+
+In `internal/workout/service.go`, near `BuildProgression`:
+
+```go
+// BuildTimedProgression constructs an exerciseprogression.TimedProgression
+// for the given time-based exercise in the given session. Returns an error if
+// the exercise is not time_based.
+func (s *Service) BuildTimedProgression(
+    ctx context.Context,
+    date time.Time,
+    exerciseID int,
+) (*exerciseprogression.TimedProgression, error) {
+    starting, err := s.GetStartingSeconds(ctx, exerciseID, date)
+    if err != nil {
+        return nil, fmt.Errorf("get starting seconds: %w", err)
+    }
+
+    sess, err := s.repo.sessions.Get(ctx, date)
+    if err != nil {
+        return nil, fmt.Errorf("get session: %w", err)
+    }
+
+    completed := make([]exerciseprogression.TimedSetResult, 0)
+    for _, exSet := range sess.ExerciseSets {
+        if exSet.Exercise.ID != exerciseID {
+            continue
+        }
+        for _, set := range exSet.Sets {
+            if set.CompletedValue == nil || set.Signal == nil {
+                continue
+            }
+            completed = append(completed, exerciseprogression.TimedSetResult{
+                ActualSeconds: *set.CompletedValue,
+                Signal:        toProgressionSignal(*set.Signal),
+            })
+        }
+    }
+    return exerciseprogression.NewTimedFromHistory(
+        exerciseprogression.TimedConfig{StartingSeconds: starting},
+        completed,
+    ), nil
+}
+```
+
+(Reuse the existing `toProgressionSignal` helper if present; otherwise inline the same Signal mapping used by `BuildProgression`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/workout/ -run Test_BuildTimedProgression -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/workout
+git commit -m "$(cat <<'EOF'
+Add BuildTimedProgression for time-based exercises
+
+Parallels BuildProgression: derives starting seconds via
+GetStartingSeconds, replays this session's completed time-based sets
+into a TimedProgression so the next CurrentSet() call returns the
+auto-regulated target.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Planner emits `time_based` sets
+
+Updates the weekplanner so that when it picks a `time_based` exercise it emits `target_value` from the exercise's default starting seconds (the planner doesn't have user history; the service layer enriches per-execution targets via `BuildTimedProgression`).
+
+**Files:**
+- Modify: `internal/weekplanner/weekplanner.go`
+- Modify: `internal/weekplanner/weekplanner_internal_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/weekplanner/weekplanner_internal_test.go`:
+
+```go
+func TestPlannerEmitsTimeBasedTarget(t *testing.T) {
+    t.Parallel()
+
+    plank := Exercise{
+        ID:                     21,
+        Name:                   "Plank",
+        Category:               CategoryUpper,
+        ExerciseType:           ExerciseTypeTime,
+        DefaultStartingSeconds: ptrInt(30),
+    }
+
+    sets := buildPlannedSets(plank, PeriodizationStrength)
+    if len(sets) != setsPerExercise {
+        t.Fatalf("len(sets) = %d, want %d", len(sets), setsPerExercise)
+    }
+    for i, s := range sets {
+        if s.TargetValue != 30 {
+            t.Errorf("set %d: TargetValue = %d, want 30", i, s.TargetValue)
+        }
+    }
+}
+
+func ptrInt(i int) *int { return &i }
+```
+
+(`buildPlannedSets` is the helper that sits inside `weekplanner.go`'s set-emission code path — extract it if it isn't already a free function. Whatever the engineer renames the existing internal logic to, the test should target the same call site that today produces `[]PlannedSet`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/weekplanner/ -run TestPlannerEmitsTimeBasedTarget -v`
+Expected: FAIL — either `Exercise.DefaultStartingSeconds` or the time-based branch missing.
+
+- [ ] **Step 3: Add `Exercise.DefaultStartingSeconds` and `ExerciseTypeTime` in the weekplanner package**
+
+The weekplanner has its own dependency-free `Exercise` struct
+(`internal/weekplanner/weekplanner.go:111`) and `ExerciseType` enum
+(`weekplanner.go:20-27`). Add `time_based` to the enum and the new field to
+the struct:
+
+```go
+const (
+    ExerciseTypeWeighted   ExerciseType = "weighted"
+    ExerciseTypeBodyweight ExerciseType = "bodyweight"
+    ExerciseTypeAssisted   ExerciseType = "assisted"
+    ExerciseTypeTime       ExerciseType = "time_based"
+)
+
+type Exercise struct {
+    ID                     int
+    Category               Category
+    ExerciseType           ExerciseType
+    PrimaryMuscleGroups    []string
+    SecondaryMuscleGroups  []string
+    DefaultStartingSeconds *int
+}
+```
+
+- [ ] **Step 3b: Copy the new field through the workout→weekplanner mapping**
+
+In `internal/workout/service.go` around line 164 there is:
+
+```go
+wpExercises[i] = weekplanner.Exercise{
+    ID:                    ex.ID,
+    Category:              weekplanner.Category(ex.Category),
+    ExerciseType:          weekplanner.ExerciseType(ex.ExerciseType),
+    PrimaryMuscleGroups:   ex.PrimaryMuscleGroups,
+    SecondaryMuscleGroups: ex.SecondaryMuscleGroups,
+}
+```
+
+Add `DefaultStartingSeconds: ex.DefaultStartingSeconds,` so the planner sees
+the time-based default at plan time.
+
+- [ ] **Step 4: Branch the set-emission path on `ExerciseTypeTime`**
+
+In the existing set-emission logic (around `weekplanner.go:424`):
+
+```go
+target := setsForPeriodization(periodization)
+if exercise.ExerciseType == ExerciseTypeTime {
+    if exercise.DefaultStartingSeconds == nil {
+        // schema CHECK guarantees a non-nil default for time_based, so this
+        // is a fixture/data invariant violation.
+        return nil, fmt.Errorf("time_based exercise %d missing DefaultStartingSeconds", exercise.ID)
+    }
+    target = *exercise.DefaultStartingSeconds
+}
+for i := range sets {
+    sets[i] = PlannedSet{TargetValue: target}
+}
+```
+
+(If the surrounding function doesn't return error today, propagate the error through whichever signature the planner uses; the spec's data invariant is enforced by the schema CHECK so this branch is genuinely unreachable in production but worth a clear panic/error for fixture-development time.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/weekplanner/ -run TestPlannerEmitsTimeBasedTarget -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run full package tests**
+
+Run: `go test ./internal/weekplanner/...`
+Expected: PASS — including all existing rep-based planner tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/weekplanner
+git commit -m "$(cat <<'EOF'
+Emit DefaultStartingSeconds as TargetValue for time_based exercises
+
+Adds the time_based branch to the planner's set-emission so picking
+plank produces the right per-set duration target. Rep-based exercises
+keep using TargetReps unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Wire `BuildTimedProgression` into the workout-execution path
+
+Updates the handler that hands the next-set target to the template. When the active exercise is `time_based`, call `BuildTimedProgression`; otherwise call `BuildProgression`. Updates `formatTarget` to receive both kinds of targets.
+
+**Files:**
+- Modify: `cmd/web/handler-exerciseset.go`
+
+- [ ] **Step 1: Identify the call site**
+
+Read `cmd/web/handler-exerciseset.go` and find where `BuildProgression` is called on the active exercise (it sits near where `CurrentSetTarget` gets populated — see the struct around line 33 from the earlier exploration).
+
+- [ ] **Step 2: Branch on `IsTimed`**
+
+Replace the single `BuildProgression` call with a branch:
+
+```go
+var targetValue int
+if exercise.IsTimed() {
+    progression, err := app.workoutService.BuildTimedProgression(r.Context(), date, exercise.ID)
+    if err != nil {
+        app.serverError(w, r, fmt.Errorf("build timed progression: %w", err))
+        return
+    }
+    targetValue = progression.CurrentSet().TargetSeconds
+} else {
+    progression, err := app.workoutService.BuildProgression(r.Context(), date, exercise.ID)
+    if err != nil {
+        app.serverError(w, r, fmt.Errorf("build progression: %w", err))
+        return
+    }
+    target := progression.CurrentSet()
+    targetValue = target.TargetReps
+    // existing weight-handling code remains for non-time_based exercises.
+}
+
+displayTarget := formatTarget(exercise, session, targetValue)
+```
+
+The existing `WeightKg`/`AbsCurrentWeight` template-data fields stay for the weighted/bodyweight/assisted branch and are not populated for `time_based`.
+
+- [ ] **Step 3: Update template data struct**
+
+Ensure the template data carries `displayTarget` (e.g., as `CurrentSetTargetStr string`). Templates should read this string instead of computing the range themselves.
+
+- [ ] **Step 4: Build and run tests**
+
+Run: `go build ./...` then `go test ./cmd/web/...`
+Expected: clean build, all handler tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/web internal/workout
+git commit -m "$(cat <<'EOF'
+Branch handler-exerciseset on IsTimed for next-set target
+
+When the active exercise is time_based, the workout view asks
+BuildTimedProgression for the current target seconds; otherwise it
+keeps using BuildProgression for the rep-and-weight path. Display
+string flows through formatTarget so templates render
+unit-appropriately without per-template branching.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Exercise-info chart — `time_based` case
+
+Adds the missing case in `processEntryData` so the progress chart renders "30s" for time-based history entries.
+
+**Files:**
+- Modify: `cmd/web/handler-exercise-info.go`
+
+- [ ] **Step 1: Find the switch**
+
+`cmd/web/handler-exercise-info.go` `processEntryData` (line ~108). After Task 2 it should already have a placeholder `case workout.ExerciseTypeTime:`.
+
+- [ ] **Step 2: Implement the case**
+
+```go
+case workout.ExerciseTypeTime:
+    if set.CompletedValue != nil {
+        setDescriptions = append(setDescriptions, fmt.Sprintf("%ds", *set.CompletedValue))
+    }
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `go test ./cmd/web/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/web/handler-exercise-info.go
+git commit -m "$(cat <<'EOF'
+Render time_based sets as Xs in the exercise progress chart
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Flip plank fixture to `time_based`
+
+Updates the seed so plank gets prescribed as a 30-second hold for new users. Existing plank rows in production were already dropped by the premigration in Task 2.
+
+**Files:**
+- Modify: `internal/sqlite/fixtures.sql`
+
+- [ ] **Step 1: Locate plank in the fixture**
+
+`internal/sqlite/fixtures.sql:329` contains the `(21, 'Plank', 'upper', 'bodyweight', '## Instructions...` row. The trailing `ON CONFLICT (name) DO UPDATE` clause at line 360 means the row will UPSERT on next boot.
+
+- [ ] **Step 2: Modify the row**
+
+Change `'bodyweight'` to `'time_based'`. Add `default_starting_seconds = 30`. The exact column list needs to include `default_starting_seconds`; if the existing INSERT statement uses positional VALUES, append the column to the column list and `30` to plank's row, leaving other rows with `NULL` — explicit:
+
+```sql
+INSERT INTO exercises (id, name, category, exercise_type, description_markdown, default_starting_seconds)
+VALUES
+  (1, 'Deadlift', 'full_body', 'weighted', '...', NULL),
+  ...
+  (21, 'Plank', 'upper', 'time_based', '## Instructions
+...content unchanged...', 30),
+  ...
+ON CONFLICT (name) DO UPDATE SET
+    category                 = excluded.category,
+    exercise_type            = excluded.exercise_type,
+    description_markdown     = excluded.description_markdown,
+    default_starting_seconds = excluded.default_starting_seconds;
+```
+
+(Look at the existing `ON CONFLICT (name) DO UPDATE` block for the exercises insert — it already lists each column being updated. Append `default_starting_seconds = excluded.default_starting_seconds` to that list.)
+
+- [ ] **Step 3: Run the database boot path**
+
+Run: `go test ./internal/sqlite/...`
+Expected: PASS — the schema CHECK rejects time_based exercises with NULL default_starting_seconds, so a typo here will fail loudly.
+
+Then run the full test suite: `make test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/sqlite/fixtures.sql
+git commit -m "$(cat <<'EOF'
+Flip plank fixture to time_based with 30s default
+
+Plank now prescribes a 30-second hold instead of nonsense reps. The
+ON CONFLICT clause re-applies on every boot so existing rows upgrade
+in place.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Admin form — `time_based` option + `default_starting_seconds`
+
+Adds the type to the admin dropdown and a number field shown only when type is `time_based`. Also wires the Service's exercise-create/update path to accept and persist `DefaultStartingSeconds`.
+
+**Files:**
+- Modify: `cmd/web/handler-admin-exercises.go`
+- Modify: relevant admin template under `ui/templates/pages/admin/`
+- Modify: `internal/workout/service.go` and `repository-exercises.go` if the create/update path needs the new field
+
+- [ ] **Step 1: Find the admin handler**
+
+`cmd/web/handler-admin-exercises.go:154` is the validation gate that today restricts `exercise_type` to known values. Read 50 lines around that point to see the form-handling shape.
+
+- [ ] **Step 2: Add `time_based` to the validation**
+
+```go
+if exerciseType != workout.ExerciseTypeWeighted &&
+    exerciseType != workout.ExerciseTypeBodyweight &&
+    exerciseType != workout.ExerciseTypeAssisted &&
+    exerciseType != workout.ExerciseTypeTime {
+    // existing error response
+}
+```
+
+- [ ] **Step 3: Parse `default_starting_seconds`**
+
+When `exerciseType == workout.ExerciseTypeTime`, parse the form field `default_starting_seconds` as a positive integer and reject the form if it's missing or non-positive. For other types, leave it nil.
+
+```go
+var defaultStartingSeconds *int
+if exerciseType == workout.ExerciseTypeTime {
+    raw := r.PostForm.Get("default_starting_seconds")
+    n, err := strconv.Atoi(raw)
+    if err != nil || n <= 0 {
+        http.Error(w, "default_starting_seconds must be a positive integer for time_based exercises", http.StatusBadRequest)
+        return
+    }
+    defaultStartingSeconds = &n
+}
+```
+
+- [ ] **Step 4: Pass the field through the service + repo**
+
+Add the field to the create/update method signatures or the `Exercise` value used by them; ensure `INSERT`/`UPDATE` SQL in `repository-exercises.go` reads/writes `default_starting_seconds`.
+
+- [ ] **Step 5: Update the admin template**
+
+Find the admin exercise form template (`ui/templates/pages/admin/exercises*.gohtml`). Add `time_based` as a fourth option to the type dropdown. Add a number input with `name="default_starting_seconds"`, label "Default starting seconds", marked `required` when type is `time_based`. Use a small inline progressive-enhancement script or HTMX-style hide/show — match the existing pattern used for hiding the weight field on `bodyweight`.
+
+- [ ] **Step 6: Run handler tests**
+
+Run: `go test ./cmd/web/ -run Admin -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/web internal/workout ui/templates
+git commit -m "$(cat <<'EOF'
+Admin form support for time_based exercises
+
+Adds time_based to the type dropdown and a default_starting_seconds
+number field shown only when the type is time_based. Service and
+repository persist the new field; schema CHECK enforces presence.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Manual smoke test
+
+End-to-end verification in the running app that wasn't covered by unit tests.
+
+- [ ] **Step 1: Boot the app fresh against an in-memory DB or a wiped local DB**
+
+```bash
+make init  # if not already done
+go run ./cmd/web
+```
+
+- [ ] **Step 2: Create a test user, configure a workout day, and start a workout that includes plank**
+
+Verify that the plank exercise card shows "Target: 30s" and a numeric input for completed seconds.
+
+- [ ] **Step 3: Submit a completed set with 35 seconds and `Signal=too_light`**
+
+Verify that the next set in the same session shows "Target: 40s" (35 + 5s ladder, rounded to nearest 5).
+
+- [ ] **Step 4: Complete all three sets and finish the session**
+
+- [ ] **Step 5: Generate the next plank session**
+
+Verify it opens at the seconds completed on the final set (per `GetLatestSuccessfulSecondsBefore`).
+
+- [ ] **Step 6: Visit the plank exercise info / progress chart page**
+
+Verify each historical entry renders `"NNs"` instead of `"NN reps"`.
+
+- [ ] **Step 7: Verify rep-based exercises are unchanged**
+
+Visit a hypertrophy bench session — display reads "6-10". Visit a strength deadlift session — display reads "5".
+
+If anything looks wrong, file the bug at the corresponding task and patch.

--- a/internal/exerciseprogression/timed_progression.go
+++ b/internal/exerciseprogression/timed_progression.go
@@ -1,0 +1,106 @@
+package exerciseprogression
+
+import (
+	"fmt"
+	"math"
+)
+
+// TimedConfig is provided once when starting a timed exercise execution.
+type TimedConfig struct {
+	StartingSeconds int // seconds; caller-derived from history, may be user-overridden
+}
+
+// TimedSetTarget is what the package recommends for the upcoming hold.
+type TimedSetTarget struct {
+	TargetSeconds int
+}
+
+// TimedSetResult is recorded by the caller after the user completes a hold.
+type TimedSetResult struct {
+	ActualSeconds int
+	Signal        Signal
+}
+
+const (
+	timedSnapSeconds   = 5
+	timedFloorSeconds  = 5
+	timedDecrFraction  = 0.10
+	timedStepShort     = 5  // < 60s
+	timedStepMid       = 10 // 60–119s
+	timedStepLong      = 15 // ≥ 120s
+	timedMidThreshold  = 60
+	timedLongThreshold = 120
+)
+
+// TimedProgression manages duration progression for one timed exercise execution.
+type TimedProgression struct {
+	config    TimedConfig
+	completed []TimedSetResult
+}
+
+// NewTimed creates a TimedProgression for a new exercise execution.
+func NewTimed(c TimedConfig) *TimedProgression {
+	return &TimedProgression{config: c, completed: nil}
+}
+
+// NewTimedFromHistory reconstructs a TimedProgression from sets already completed in this session.
+func NewTimedFromHistory(c TimedConfig, completed []TimedSetResult) *TimedProgression {
+	p := NewTimed(c)
+	p.completed = make([]TimedSetResult, len(completed))
+	copy(p.completed, completed)
+	return p
+}
+
+// CurrentSet returns the recommended target for the next hold.
+func (p *TimedProgression) CurrentSet() TimedSetTarget {
+	if len(p.completed) == 0 {
+		return TimedSetTarget{TargetSeconds: p.config.StartingSeconds}
+	}
+	last := p.completed[len(p.completed)-1]
+	return TimedSetTarget{TargetSeconds: adjustedSeconds(last)}
+}
+
+// RecordCompletion records what actually happened and advances internal state.
+func (p *TimedProgression) RecordCompletion(r TimedSetResult) {
+	p.completed = append(p.completed, r)
+}
+
+// SetsCompleted returns the number of holds recorded so far.
+func (p *TimedProgression) SetsCompleted() int {
+	return len(p.completed)
+}
+
+func adjustedSeconds(last TimedSetResult) int {
+	step := timedIncrement(last.ActualSeconds)
+	switch last.Signal {
+	case SignalTooLight:
+		return snap5(last.ActualSeconds + step)
+	case SignalTooHeavy:
+		decrement := step
+		if pct := snap5(int(math.Round(float64(last.ActualSeconds) * timedDecrFraction))); pct > decrement {
+			decrement = pct
+		}
+		next := max(last.ActualSeconds-decrement, timedFloorSeconds)
+		return snap5(next)
+	case SignalOnTarget:
+		return last.ActualSeconds
+	case SignalUnknown:
+		panic("exerciseprogression: TimedSetResult must not use SignalUnknown")
+	}
+	panic(fmt.Sprintf("exerciseprogression: unhandled Signal %d", last.Signal))
+}
+
+func timedIncrement(current int) int {
+	switch {
+	case current < timedMidThreshold:
+		return timedStepShort
+	case current < timedLongThreshold:
+		return timedStepMid
+	default:
+		return timedStepLong
+	}
+}
+
+func snap5(seconds int) int {
+	return int(math.Round(float64(seconds)/float64(timedSnapSeconds))) * timedSnapSeconds
+}

--- a/internal/exerciseprogression/timed_progression_test.go
+++ b/internal/exerciseprogression/timed_progression_test.go
@@ -1,0 +1,110 @@
+package exerciseprogression_test
+
+import (
+	"testing"
+
+	"github.com/myrjola/petrapp/internal/exerciseprogression"
+)
+
+func TestTimedProgressionCurrentSet(t *testing.T) {
+	t.Parallel()
+
+	type setup struct {
+		startingSeconds int
+		completed       []exerciseprogression.TimedSetResult
+	}
+	tests := []struct {
+		name string
+		in   setup
+		want int
+	}{
+		{
+			name: "first set returns starting seconds",
+			in:   setup{startingSeconds: 30, completed: nil},
+			want: 30,
+		},
+		{
+			name: "on_target keeps target",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 30, Signal: exerciseprogression.SignalOnTarget},
+			}},
+			want: 30,
+		},
+		{
+			name: "too_light under 60s bumps by 5",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 30, Signal: exerciseprogression.SignalTooLight},
+			}},
+			want: 35,
+		},
+		{
+			name: "too_light at 60s bumps by 10",
+			in: setup{startingSeconds: 60, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 60, Signal: exerciseprogression.SignalTooLight},
+			}},
+			want: 70,
+		},
+		{
+			name: "too_light at 120s bumps by 15",
+			in: setup{startingSeconds: 120, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 120, Signal: exerciseprogression.SignalTooLight},
+			}},
+			want: 135,
+		},
+		{
+			name: "too_heavy under 60s drops by 5",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 20, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			want: 15,
+		},
+		{
+			name: "too_heavy 10% drop snapped to 5s when larger than ladder step",
+			in: setup{startingSeconds: 90, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 70, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			// 10% of 70 = 7, snap5 = 5, ladder at 60-119s = 10 → max(10,5) = 10 → 60
+			want: 60,
+		},
+		{
+			name: "too_heavy floors at 5s",
+			in: setup{startingSeconds: 5, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 5, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			want: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := exerciseprogression.NewTimedFromHistory(
+				exerciseprogression.TimedConfig{StartingSeconds: tt.in.startingSeconds},
+				tt.in.completed,
+			)
+			got := p.CurrentSet().TargetSeconds
+			if got != tt.want {
+				t.Errorf("TargetSeconds = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimedProgressionRecordCompletion(t *testing.T) {
+	t.Parallel()
+
+	p := exerciseprogression.NewTimed(exerciseprogression.TimedConfig{StartingSeconds: 30})
+	if got := p.SetsCompleted(); got != 0 {
+		t.Fatalf("SetsCompleted before any record = %d, want 0", got)
+	}
+	p.RecordCompletion(exerciseprogression.TimedSetResult{
+		ActualSeconds: 30,
+		Signal:        exerciseprogression.SignalOnTarget,
+	})
+	if got := p.SetsCompleted(); got != 1 {
+		t.Errorf("SetsCompleted after one record = %d, want 1", got)
+	}
+	if got := p.CurrentSet().TargetSeconds; got != 30 {
+		t.Errorf("TargetSeconds after on_target = %d, want 30", got)
+	}
+}

--- a/internal/exerciseprogression/timed_progression_test.go
+++ b/internal/exerciseprogression/timed_progression_test.go
@@ -59,12 +59,36 @@ func TestTimedProgressionCurrentSet(t *testing.T) {
 			want: 15,
 		},
 		{
-			name: "too_heavy 10% drop snapped to 5s when larger than ladder step",
+			name: "too_heavy uses ladder step when it exceeds 10% decrement",
 			in: setup{startingSeconds: 90, completed: []exerciseprogression.TimedSetResult{
 				{ActualSeconds: 70, Signal: exerciseprogression.SignalTooHeavy},
 			}},
 			// 10% of 70 = 7, snap5 = 5, ladder at 60-119s = 10 → max(10,5) = 10 → 60
 			want: 60,
+		},
+		{
+			name: "too_heavy at 120s drops by 15s ladder step",
+			in: setup{startingSeconds: 130, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 120, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			// ladder at >=120s = 15; 10% of 120 = 12, snap5(12) = 10; max(15, 10) = 15 → 105
+			want: 105,
+		},
+		{
+			name: "too_heavy at 200s where 10% percentage exceeds ladder step",
+			in: setup{startingSeconds: 210, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 200, Signal: exerciseprogression.SignalTooHeavy},
+			}},
+			// ladder at >=120s = 15; 10% of 200 = 20, snap5(20) = 20; max(15, 20) = 20 → 180
+			want: 180,
+		},
+		{
+			name: "too_light snaps off-grid actual to nearest 5",
+			in: setup{startingSeconds: 30, completed: []exerciseprogression.TimedSetResult{
+				{ActualSeconds: 27, Signal: exerciseprogression.SignalTooLight},
+			}},
+			// 27 + 5 (ladder) = 32, snap5(32) = 30
+			want: 30,
 		},
 		{
 			name: "too_heavy floors at 5s",

--- a/internal/sqlite/fixtures.sql
+++ b/internal/sqlite/fixtures.sql
@@ -362,6 +362,14 @@ UPDATE SET category = excluded.category,
     exercise_type = excluded.exercise_type,
     description_markdown = excluded.description_markdown;
 
+-- Plank is a time-based hold; the main INSERT above leaves it as 'bodyweight'
+-- so the schema CHECK doesn't reject the row (time_based requires a non-null
+-- default_starting_seconds). This atomic UPDATE flips both columns at once.
+UPDATE exercises
+SET exercise_type            = 'time_based',
+    default_starting_seconds = 30
+WHERE name = 'Plank';
+
 INSERT INTO exercise_muscle_groups (exercise_id, muscle_group_name, is_primary)
 VALUES (1, 'Forearms', 0),
        (1, 'Glutes', 1),

--- a/internal/sqlite/migrate_internal_test.go
+++ b/internal/sqlite/migrate_internal_test.go
@@ -1,11 +1,119 @@
 package sqlite
 
 import (
+	"context"
+	"io"
 	"log/slog"
 	"testing"
 
 	"github.com/myrjola/petrapp/internal/testhelpers"
 )
+
+const legacyExerciseSetsSchema = `
+CREATE TABLE workout_sessions (
+	user_id            INTEGER NOT NULL,
+	workout_date       TEXT    NOT NULL,
+	difficulty_rating  INTEGER,
+	started_at         TEXT,
+	completed_at       TEXT,
+	periodization_type TEXT NOT NULL DEFAULT 'strength',
+	PRIMARY KEY (user_id, workout_date)
+) WITHOUT ROWID, STRICT;
+
+CREATE TABLE workout_exercise (
+	id                  INTEGER PRIMARY KEY,
+	workout_user_id     INTEGER NOT NULL,
+	workout_date        TEXT    NOT NULL,
+	exercise_id         INTEGER NOT NULL,
+	warmup_completed_at TEXT
+) STRICT;
+
+CREATE TABLE exercises (
+	id                   INTEGER PRIMARY KEY,
+	name                 TEXT NOT NULL UNIQUE,
+	category             TEXT NOT NULL,
+	exercise_type        TEXT NOT NULL DEFAULT 'weighted',
+	description_markdown TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE TABLE exercise_sets (
+	workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
+	set_number          INTEGER NOT NULL CHECK (set_number > 0),
+	weight_kg           REAL,
+	min_reps            INTEGER NOT NULL CHECK (min_reps > 0),
+	max_reps            INTEGER NOT NULL CHECK (max_reps >= min_reps),
+	completed_reps      INTEGER CHECK (completed_reps IS NULL OR completed_reps >= 0),
+	completed_at        TEXT,
+	signal              TEXT,
+	PRIMARY KEY (workout_exercise_id, set_number)
+) WITHOUT ROWID, STRICT;
+`
+
+func TestPreMigrateExerciseSetTarget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	db, err := connect(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if _, err = db.ReadWrite.ExecContext(ctx, legacyExerciseSetsSchema); err != nil {
+		t.Fatalf("apply legacy schema: %v", err)
+	}
+	// Legacy seed: hypertrophy bench (min=6, max=10, completed=8) and a plank row.
+	seed := "INSERT INTO exercises (id, name, category, exercise_type) VALUES " +
+		"(1, 'Bench Press', 'upper', 'weighted'), (2, 'Plank', 'upper', 'bodyweight');" +
+		"INSERT INTO workout_sessions (user_id, workout_date, periodization_type) VALUES " +
+		"(1, '2026-04-01', 'hypertrophy');" +
+		"INSERT INTO workout_exercise (id, workout_user_id, workout_date, exercise_id) VALUES " +
+		"(10, 1, '2026-04-01', 1), (11, 1, '2026-04-01', 2);" +
+		"INSERT INTO exercise_sets " +
+		"(workout_exercise_id, set_number, weight_kg, min_reps, max_reps, completed_reps, signal) VALUES " +
+		"(10, 1, 60.0, 6, 10, 8, 'on_target'), (11, 1, NULL, 5, 5, 5, 'on_target');"
+	if _, err = db.ReadWrite.ExecContext(ctx, seed); err != nil {
+		t.Fatalf("seed legacy data: %v", err)
+	}
+
+	if err = db.preMigrateExerciseSetTarget(ctx); err != nil {
+		t.Fatalf("preMigrate: %v", err)
+	}
+
+	// Bench row: target_value = max_reps = 10, completed_value = 8.
+	var target, completed int
+	if err = db.ReadWrite.QueryRowContext(ctx,
+		`SELECT target_value, completed_value FROM exercise_sets WHERE workout_exercise_id = 10`,
+	).Scan(&target, &completed); err != nil {
+		t.Fatalf("read bench row: %v", err)
+	}
+	if target != 10 || completed != 8 {
+		t.Errorf("bench row: target=%d completed=%d, want 10 and 8", target, completed)
+	}
+
+	// Plank row dropped.
+	var plankCount int
+	if err = db.ReadWrite.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM exercise_sets WHERE workout_exercise_id = 11`,
+	).Scan(&plankCount); err != nil {
+		t.Fatalf("count plank rows: %v", err)
+	}
+	if plankCount != 0 {
+		t.Errorf("plank rows after migration = %d, want 0", plankCount)
+	}
+
+	// Idempotent: second call is a no-op and does not error.
+	if err = db.preMigrateExerciseSetTarget(ctx); err != nil {
+		t.Fatalf("preMigrate idempotent call: %v", err)
+	}
+
+	// Declarative migrator must accept the new schema as no-op for exercise_sets.
+	if err = db.migrateTo(ctx, schemaDefinition); err != nil {
+		t.Fatalf("migrateTo after premigration: %v", err)
+	}
+}
 
 func TestDatabase_migrate(t *testing.T) {
 	t.Parallel()

--- a/internal/sqlite/premigrate.go
+++ b/internal/sqlite/premigrate.go
@@ -1,0 +1,92 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// preMigrateExerciseSetTarget rewrites the legacy exercise_sets shape
+// (min_reps/max_reps/completed_reps) into the collapsed target_value/
+// completed_value shape, dropping historical Plank rows whose reps would be
+// nonsensical to reinterpret as seconds. Idempotent and safe on a fresh DB.
+//
+// Delete this file, its call site in NewDatabase, the test in
+// migrate_internal_test.go, and the legacy schema constant once it has run
+// in production.
+func (db *Database) preMigrateExerciseSetTarget(ctx context.Context) error {
+	// Already migrated? (target_value column exists)
+	var hasTarget int
+	err := db.ReadWrite.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('exercise_sets') WHERE name = 'target_value'`,
+	).Scan(&hasTarget)
+	if err != nil {
+		return fmt.Errorf("pragma_table_info exercise_sets: %w", err)
+	}
+	if hasTarget > 0 {
+		return nil
+	}
+
+	// Fresh DB? (no exercise_sets table at all)
+	var hasTable int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='exercise_sets'`,
+	).Scan(&hasTable)
+	if err != nil {
+		return fmt.Errorf("sqlite_master exercise_sets: %w", err)
+	}
+	if hasTable == 0 {
+		return nil
+	}
+
+	if _, err = db.ReadWrite.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("disable foreign keys: %w", err)
+	}
+
+	tx, err := db.ReadWrite.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+				err = fmt.Errorf("%w; rollback: %w", err, rbErr)
+			}
+		}
+	}()
+
+	stmts := []string{
+		`CREATE TABLE exercise_sets_new (
+			workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
+			set_number          INTEGER NOT NULL CHECK (set_number > 0),
+			weight_kg           REAL,
+			target_value        INTEGER NOT NULL CHECK (target_value > 0),
+			completed_value     INTEGER CHECK (completed_value IS NULL OR completed_value >= 0),
+			completed_at        TEXT CHECK (completed_at IS NULL OR
+			                                STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),
+			signal              TEXT CHECK (signal IS NULL OR signal IN ('too_heavy', 'on_target', 'too_light')),
+			PRIMARY KEY (workout_exercise_id, set_number)
+		) WITHOUT ROWID, STRICT`,
+		`INSERT INTO exercise_sets_new
+			(workout_exercise_id, set_number, weight_kg, target_value,
+			 completed_value, completed_at, signal)
+		 SELECT s.workout_exercise_id, s.set_number, s.weight_kg,
+		        s.max_reps, s.completed_reps, s.completed_at, s.signal
+		   FROM exercise_sets s
+		   JOIN workout_exercise wx ON wx.id = s.workout_exercise_id
+		   JOIN exercises e         ON e.id = wx.exercise_id
+		  WHERE e.name <> 'Plank'`,
+		`DROP TABLE exercise_sets`,
+		`ALTER TABLE exercise_sets_new RENAME TO exercise_sets`,
+	}
+	for _, q := range stmts {
+		if _, err = tx.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("premigrate exercise_sets: %w", err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+	return nil
+}

--- a/internal/sqlite/schema.sql
+++ b/internal/sqlite/schema.sql
@@ -80,11 +80,14 @@ CREATE TABLE workout_preferences
 
 CREATE TABLE exercises
 (
-    id                   INTEGER PRIMARY KEY,
-    name                 TEXT NOT NULL UNIQUE CHECK (LENGTH(name) < 124),
-    category             TEXT NOT NULL CHECK (category IN ('full_body', 'upper', 'lower')),
-    exercise_type        TEXT NOT NULL DEFAULT 'weighted' CHECK (exercise_type IN ('weighted', 'bodyweight', 'assisted')),
-    description_markdown TEXT NOT NULL DEFAULT '' CHECK (LENGTH(description_markdown) < 20000)
+    id                       INTEGER PRIMARY KEY,
+    name                     TEXT    NOT NULL UNIQUE CHECK (LENGTH(name) < 124),
+    category                 TEXT    NOT NULL CHECK (category IN ('full_body', 'upper', 'lower')),
+    exercise_type            TEXT    NOT NULL DEFAULT 'weighted'
+                             CHECK (exercise_type IN ('weighted', 'bodyweight', 'assisted', 'time_based')),
+    description_markdown     TEXT    NOT NULL DEFAULT '' CHECK (LENGTH(description_markdown) < 20000),
+    default_starting_seconds INTEGER CHECK (default_starting_seconds IS NULL OR default_starting_seconds > 0),
+    CHECK (exercise_type <> 'time_based' OR default_starting_seconds IS NOT NULL)
 ) STRICT;
 
 CREATE TABLE workout_sessions
@@ -123,10 +126,10 @@ CREATE TABLE exercise_sets
     workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
     set_number          INTEGER NOT NULL CHECK (set_number > 0),
     weight_kg           REAL,
-    min_reps            INTEGER NOT NULL CHECK (min_reps > 0),
-    max_reps            INTEGER NOT NULL CHECK (max_reps >= min_reps),
-    completed_reps      INTEGER CHECK (completed_reps IS NULL OR completed_reps >= 0),
-    completed_at        TEXT CHECK (completed_at IS NULL OR STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),
+    target_value        INTEGER NOT NULL CHECK (target_value > 0),
+    completed_value     INTEGER CHECK (completed_value IS NULL OR completed_value >= 0),
+    completed_at        TEXT CHECK (completed_at IS NULL OR
+                                    STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),
     signal              TEXT CHECK (signal IS NULL OR signal IN ('too_heavy', 'on_target', 'too_light')),
 
     PRIMARY KEY (workout_exercise_id, set_number)

--- a/internal/sqlite/sqlite.go
+++ b/internal/sqlite/sqlite.go
@@ -52,6 +52,10 @@ func NewDatabase(ctx context.Context, url string, logger *slog.Logger) (*Databas
 		return nil, fmt.Errorf("connect: %w", err)
 	}
 
+	if err = db.preMigrateExerciseSetTarget(ctx); err != nil {
+		return nil, fmt.Errorf("preMigrateExerciseSetTarget: %w", err)
+	}
+
 	if err = db.migrateTo(ctx, schemaDefinition); err != nil {
 		return nil, fmt.Errorf("migrateTo: %w", err)
 	}

--- a/internal/weekplanner/weekplanner.go
+++ b/internal/weekplanner/weekplanner.go
@@ -35,11 +35,9 @@ const (
 )
 
 const (
-	setsPerExercise    = 3
-	minRepsStrength    = 5
-	maxRepsStrength    = 5
-	minRepsHypertrophy = 6
-	maxRepsHypertrophy = 10
+	setsPerExercise = 3
+	repsStrength    = 5
+	repsHypertrophy = 8
 )
 
 const (
@@ -136,10 +134,10 @@ type PlannedExerciseSet struct {
 	Sets       []PlannedSet
 }
 
-// PlannedSet holds rep targets only; WeightKg is always nil at plan time.
+// PlannedSet holds the target value only; WeightKg is always nil at plan time.
+// The unit (reps or seconds) is derived from the parent exercise type.
 type PlannedSet struct {
-	MinReps int
-	MaxReps int
+	TargetValue int
 }
 
 // WeeklyPlanner holds the static inputs needed to plan a full week of workouts.
@@ -293,12 +291,12 @@ func (wp *WeeklyPlanner) allocateMuscleGroups(
 	return result
 }
 
-// setsForPeriodization returns MinReps/MaxReps for a PlannedSet based on periodization type.
-func setsForPeriodization(pt PeriodizationType) (int, int) {
+// setsForPeriodization returns the target value for a PlannedSet based on periodization type.
+func setsForPeriodization(pt PeriodizationType) int {
 	if pt == PeriodizationStrength {
-		return minRepsStrength, maxRepsStrength
+		return repsStrength
 	}
-	return minRepsHypertrophy, maxRepsHypertrophy
+	return repsHypertrophy
 }
 
 // primaryMuscleGroupsOverlap returns true if any of the exercise's primary muscle groups
@@ -418,10 +416,10 @@ func (wp *WeeklyPlanner) selectExercisesForDayWithPeriodization(
 	}
 
 	// Build PlannedExerciseSets.
-	minR, maxR := setsForPeriodization(pt)
+	targetValue := setsForPeriodization(pt)
 	sets := make([]PlannedSet, setsPerExercise)
 	for i := range sets {
-		sets[i] = PlannedSet{MinReps: minR, MaxReps: maxR}
+		sets[i] = PlannedSet{TargetValue: targetValue}
 	}
 
 	result := make([]PlannedExerciseSet, len(selected))

--- a/internal/weekplanner/weekplanner.go
+++ b/internal/weekplanner/weekplanner.go
@@ -17,13 +17,14 @@ const (
 	CategoryLower    Category = "lower"
 )
 
-// ExerciseType distinguishes weighted, bodyweight, and assisted exercises.
+// ExerciseType distinguishes weighted, bodyweight, assisted, and time-based exercises.
 type ExerciseType string
 
 const (
 	ExerciseTypeWeighted   ExerciseType = "weighted"
 	ExerciseTypeBodyweight ExerciseType = "bodyweight"
 	ExerciseTypeAssisted   ExerciseType = "assisted"
+	ExerciseTypeTime       ExerciseType = "time_based"
 )
 
 // PeriodizationType controls rep targets for the session.
@@ -107,11 +108,12 @@ func (p Preferences) ExercisesPerSession(weekday time.Weekday) int {
 // Exercise is a dependency-free representation of an exercise for planning.
 // StartingWeightKg is intentionally absent — resolved lazily by exerciseprogression.
 type Exercise struct {
-	ID                    int
-	Category              Category
-	ExerciseType          ExerciseType
-	PrimaryMuscleGroups   []string
-	SecondaryMuscleGroups []string
+	ID                     int
+	Category               Category
+	ExerciseType           ExerciseType
+	PrimaryMuscleGroups    []string
+	SecondaryMuscleGroups  []string
+	DefaultStartingSeconds *int
 }
 
 // MuscleGroupTarget holds the minimum weekly set target for a tracked muscle group.
@@ -415,21 +417,34 @@ func (wp *WeeklyPlanner) selectExercisesForDayWithPeriodization(
 		selected = append(selected, ex)
 	}
 
-	// Build PlannedExerciseSets.
-	targetValue := setsForPeriodization(pt)
-	sets := make([]PlannedSet, setsPerExercise)
-	for i := range sets {
-		sets[i] = PlannedSet{TargetValue: targetValue}
-	}
-
+	// Build PlannedExerciseSets. Time-based exercises use their own
+	// DefaultStartingSeconds; rep-based exercises use the periodization target.
+	repTarget := setsForPeriodization(pt)
 	result := make([]PlannedExerciseSet, len(selected))
 	for i, ex := range selected {
-		result[i] = PlannedExerciseSet{
-			ExerciseID: ex.ID,
-			Sets:       slices.Clone(sets),
-		}
+		result[i] = buildPlannedExerciseSet(ex, repTarget)
 	}
 	return result
+}
+
+// buildPlannedExerciseSet creates a PlannedExerciseSet for one exercise.
+// Time-based exercises use DefaultStartingSeconds as target; rep-based use repTarget.
+func buildPlannedExerciseSet(ex Exercise, repTarget int) PlannedExerciseSet {
+	target := repTarget
+	if ex.ExerciseType == ExerciseTypeTime {
+		if ex.DefaultStartingSeconds == nil {
+			panic(fmt.Sprintf("time_based exercise %d missing DefaultStartingSeconds (fixture invariant violation)", ex.ID))
+		}
+		target = *ex.DefaultStartingSeconds
+	}
+	sets := make([]PlannedSet, setsPerExercise)
+	for j := range sets {
+		sets[j] = PlannedSet{TargetValue: target}
+	}
+	return PlannedExerciseSet{
+		ExerciseID: ex.ID,
+		Sets:       sets,
+	}
 }
 
 // hasExercisesForCategory reports whether the exercise pool contains at least one

--- a/internal/weekplanner/weekplanner_internal_test.go
+++ b/internal/weekplanner/weekplanner_internal_test.go
@@ -281,12 +281,11 @@ func TestSelectExercisesForDay(t *testing.T) {
 		}
 	})
 
-	t.Run("strength periodization sets correct rep range", func(t *testing.T) {
+	t.Run("strength periodization sets correct target value", func(t *testing.T) {
 		sets := wp.selectExercisesForDay(CategoryUpper, nil, 1)
 		for _, s := range sets[0].Sets {
-			if s.MinReps != minRepsStrength || s.MaxReps != maxRepsStrength {
-				t.Errorf("strength set: want min=%d max=%d, got min=%d max=%d",
-					minRepsStrength, maxRepsStrength, s.MinReps, s.MaxReps)
+			if s.TargetValue != repsStrength {
+				t.Errorf("strength set: want TargetValue=%d, got %d", repsStrength, s.TargetValue)
 			}
 		}
 	})

--- a/internal/weekplanner/weekplanner_internal_test.go
+++ b/internal/weekplanner/weekplanner_internal_test.go
@@ -146,21 +146,29 @@ func TestFirstSessionPeriodizationType(t *testing.T) {
 func minimalExercises() []Exercise {
 	return []Exercise{
 		{ID: 1, Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Quads", "Glutes"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Quads", "Glutes"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 2, Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Hamstrings"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Hamstrings"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Chest", "Triceps", "Shoulders"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Chest", "Triceps", "Shoulders"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 4, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Lats", "Upper Back"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Lats", "Upper Back"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 5, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Biceps"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Biceps"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 6, Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Hamstrings", "Glutes"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Hamstrings", "Glutes"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 7, Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 		{ID: 8, Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups: []string{"Quads"}, SecondaryMuscleGroups: nil},
+			PrimaryMuscleGroups: []string{"Quads"}, SecondaryMuscleGroups: nil,
+			DefaultStartingSeconds: nil},
 	}
 }
 
@@ -296,13 +304,17 @@ func TestSelectExercisesForDaySessionDiversity(t *testing.T) {
 		// Exercise pool: multiple exercises that could target overlapping muscles.
 		exercises := []Exercise{
 			{ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Triceps"}},
+				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Triceps"},
+				DefaultStartingSeconds: nil},
 			{ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Shoulders"}},
+				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Shoulders"},
+				DefaultStartingSeconds: nil},
 			{ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Shoulders", "Triceps"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Shoulders", "Triceps"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 			{ID: 4, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Triceps"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Triceps"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 		}
 
 		p := prefs(time.Tuesday) // 3 exercises
@@ -340,11 +352,14 @@ func TestSelectExercisesForDaySessionDiversity(t *testing.T) {
 		// Exercise pool: all Chest exercises have overlapping primary muscles.
 		exercises := []Exercise{
 			{ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 			{ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest", "Triceps"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Chest", "Triceps"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 			{ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest", "Shoulders"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Chest", "Shoulders"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 		}
 
 		p := prefs(time.Tuesday) // 3 exercises
@@ -386,11 +401,14 @@ func TestSelectExercisesForDayWeekDeduplication(t *testing.T) {
 	t.Run("exercise used earlier in week is skipped", func(t *testing.T) {
 		exercises := []Exercise{
 			{ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 			{ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 			{ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Triceps"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Triceps"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 		}
 
 		p := prefs(time.Tuesday)
@@ -457,9 +475,11 @@ func TestSelectExercisesForDayGracefulDegradation(t *testing.T) {
 		// Exercise pool: only 2 non-overlapping exercises available.
 		exercises := []Exercise{
 			{ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 			{ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil},
+				PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
+				DefaultStartingSeconds: nil},
 		}
 
 		p := prefs(time.Tuesday) // Requests 3 exercises
@@ -492,6 +512,58 @@ func TestSelectExercisesForDayGracefulDegradation(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestSelectExercisesForDay_TimeBasedTarget(t *testing.T) {
+	t.Parallel()
+
+	starting := 30
+	plank := Exercise{
+		ID:                     21,
+		Category:               CategoryUpper,
+		ExerciseType:           ExerciseTypeTime,
+		PrimaryMuscleGroups:    []string{"Abs"},
+		SecondaryMuscleGroups:  nil,
+		DefaultStartingSeconds: &starting,
+	}
+
+	wp := &WeeklyPlanner{
+		Prefs: Preferences{
+			MondayMinutes:    60,
+			TuesdayMinutes:   0,
+			WednesdayMinutes: 0,
+			ThursdayMinutes:  0,
+			FridayMinutes:    0,
+			SaturdayMinutes:  0,
+			SundayMinutes:    0,
+		},
+		Exercises: []Exercise{plank},
+		Targets:   []MuscleGroupTarget{{Name: "Abs", WeeklySetTarget: 8}},
+		rng:       nil,
+	}
+
+	sets := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper,
+		[]string{"Abs"},
+		1,
+		PeriodizationStrength,
+		map[int]bool{},
+	)
+
+	if len(sets) != 1 {
+		t.Fatalf("got %d PlannedExerciseSets, want 1", len(sets))
+	}
+	if sets[0].ExerciseID != plank.ID {
+		t.Fatalf("got exerciseID %d, want %d", sets[0].ExerciseID, plank.ID)
+	}
+	if len(sets[0].Sets) != setsPerExercise {
+		t.Fatalf("got %d sets, want %d", len(sets[0].Sets), setsPerExercise)
+	}
+	for i, s := range sets[0].Sets {
+		if s.TargetValue != 30 {
+			t.Errorf("set %d: TargetValue = %d, want 30 (DefaultStartingSeconds)", i, s.TargetValue)
+		}
+	}
 }
 
 func findExercise(exercises []Exercise, id int) Exercise {

--- a/internal/workout/CLAUDE.md
+++ b/internal/workout/CLAUDE.md
@@ -24,13 +24,14 @@ Guidelines for working with domain models, business logic, and data access patte
 
 ```go
 type Exercise struct {
-    ID                    int
-    Name                  string
-    Category              Category     // full_body, upper, lower
-    ExerciseType          ExerciseType // weighted, bodyweight
-    DescriptionMarkdown   string
-    PrimaryMuscleGroups   []string
-    SecondaryMuscleGroups []string
+    ID                     int
+    Name                   string
+    Category               Category     // full_body, upper, lower
+    ExerciseType           ExerciseType // weighted, bodyweight, assisted, time_based
+    DescriptionMarkdown    string
+    PrimaryMuscleGroups    []string
+    SecondaryMuscleGroups  []string
+    DefaultStartingSeconds *int         // Non-nil for time_based exercises; nil otherwise.
 }
 
 type Session struct {
@@ -48,11 +49,11 @@ type ExerciseSet struct {
 }
 
 type Set struct {
-    WeightKg      *float64   // Nullable for bodyweight exercises
-    MinReps       int
-    MaxReps       int
-    CompletedReps *int       // Actual reps completed
-    CompletedAt   *time.Time // When set was completed
+    WeightKg       *float64   // Nullable for bodyweight and time_based exercises.
+    TargetValue    int        // Reps if rep-based, seconds if time_based — unit derived from parent Exercise.
+    CompletedValue *int       // Same unit as TargetValue.
+    CompletedAt    *time.Time
+    Signal         *Signal
 }
 ```
 

--- a/internal/workout/models.go
+++ b/internal/workout/models.go
@@ -22,6 +22,7 @@ const (
 	ExerciseTypeWeighted   ExerciseType = "weighted"
 	ExerciseTypeBodyweight ExerciseType = "bodyweight"
 	ExerciseTypeAssisted   ExerciseType = "assisted"
+	ExerciseTypeTime       ExerciseType = "time_based"
 )
 
 // PeriodizationType determines the fixed rep target for all exercises in a session.
@@ -43,14 +44,18 @@ const (
 
 // Exercise represents a single exercise type, e.g. Squat, Bench Press, etc.
 type Exercise struct {
-	ID                    int          `json:"id"`
-	Name                  string       `json:"name"`
-	Category              Category     `json:"category"`
-	ExerciseType          ExerciseType `json:"exercise_type"`
-	DescriptionMarkdown   string       `json:"description_markdown"`
-	PrimaryMuscleGroups   []string     `json:"primary_muscle_groups"`
-	SecondaryMuscleGroups []string     `json:"secondary_muscle_groups"`
+	ID                     int          `json:"id"`
+	Name                   string       `json:"name"`
+	Category               Category     `json:"category"`
+	ExerciseType           ExerciseType `json:"exercise_type"`
+	DescriptionMarkdown    string       `json:"description_markdown"`
+	PrimaryMuscleGroups    []string     `json:"primary_muscle_groups"`
+	SecondaryMuscleGroups  []string     `json:"secondary_muscle_groups"`
+	DefaultStartingSeconds *int         `json:"default_starting_seconds,omitempty"`
 }
+
+// IsTimed returns true if this exercise uses duration targets instead of rep counts.
+func (e Exercise) IsTimed() bool { return e.ExerciseType == ExerciseTypeTime }
 
 // Resource represents a learning resource for an exercise.
 type Resource struct {
@@ -90,8 +95,12 @@ func (ejs exerciseJSONSchema) MarshalJSON() ([]byte, error) {
 			},
 			"exercise_type": map[string]any{
 				"type":        "string",
-				"description": "Type of exercise: weighted, bodyweight, or assisted",
-				"enum":        []string{"weighted", "bodyweight", "assisted"},
+				"description": "Type of exercise: weighted, bodyweight, assisted, or time_based",
+				"enum":        []string{"weighted", "bodyweight", "assisted", "time_based"},
+			},
+			"default_starting_seconds": map[string]any{
+				"type":        "integer",
+				"description": "Default starting seconds for time_based exercises; omit for other types",
 			},
 			"description_markdown": map[string]any{
 				"type":        "string",
@@ -125,12 +134,11 @@ func (ejs exerciseJSONSchema) MarshalJSON() ([]byte, error) {
 
 // Set represents a single set of an exercise with target and actual performance.
 type Set struct {
-	WeightKg      *float64 // Nullable for bodyweight exercises
-	MinReps       int
-	MaxReps       int
-	CompletedReps *int
-	CompletedAt   *time.Time // Nullable timestamp when set was completed
-	Signal        *Signal    // Nullable; nil until the set is completed
+	WeightKg       *float64   // Nullable for bodyweight and time_based exercises.
+	TargetValue    int        // Reps or seconds; unit derived from the parent exercise type.
+	CompletedValue *int       // Same unit as TargetValue; nil until the set is completed.
+	CompletedAt    *time.Time // Nullable timestamp when set was completed.
+	Signal         *Signal    // Nullable; nil until the set is completed.
 }
 
 // ExerciseSet groups all sets for a specific exercise in a workout.

--- a/internal/workout/repository-exercises.go
+++ b/internal/workout/repository-exercises.go
@@ -200,11 +200,6 @@ func (r *sqliteExerciseRepository) Update(
 
 // set creates or updates an exercise with optional upsert.
 func (r *sqliteExerciseRepository) set(ctx context.Context, ex Exercise, upsert bool) (_ Exercise, err error) {
-	// time_based exercises currently cannot be created or updated through this
-	// path: default_starting_seconds is not written, so the schema CHECK
-	// (exercise_type <> 'time_based' OR default_starting_seconds IS NOT NULL)
-	// fails. Task 9 (admin form support) will add the column to both INSERTs.
-
 	// Begin transaction
 	tx, err := r.db.ReadWrite.BeginTx(ctx, nil)
 	if err != nil {
@@ -232,15 +227,15 @@ func (r *sqliteExerciseRepository) set(ctx context.Context, ex Exercise, upsert 
 	if upsert {
 		// When upserting, use the existing ID
 		result, err = tx.ExecContext(ctx, `
-			INSERT INTO exercises (id, name, category, exercise_type, description_markdown)
-			VALUES (?, ?, ?, ?, ?)`,
-			ex.ID, ex.Name, ex.Category, ex.ExerciseType, ex.DescriptionMarkdown)
+			INSERT INTO exercises (id, name, category, exercise_type, description_markdown, default_starting_seconds)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			ex.ID, ex.Name, ex.Category, ex.ExerciseType, ex.DescriptionMarkdown, ex.DefaultStartingSeconds)
 	} else {
 		// When creating new, let SQLite assign the ID
 		result, err = tx.ExecContext(ctx, `
-			INSERT INTO exercises (name, category, exercise_type, description_markdown)
-			VALUES (?, ?, ?, ?)`,
-			ex.Name, ex.Category, ex.ExerciseType, ex.DescriptionMarkdown)
+			INSERT INTO exercises (name, category, exercise_type, description_markdown, default_starting_seconds)
+			VALUES (?, ?, ?, ?, ?)`,
+			ex.Name, ex.Category, ex.ExerciseType, ex.DescriptionMarkdown, ex.DefaultStartingSeconds)
 	}
 
 	if err != nil {

--- a/internal/workout/repository-exercises.go
+++ b/internal/workout/repository-exercises.go
@@ -24,9 +24,10 @@ func newSQLiteExerciseRepository(db *sqlite.Database) *sqliteExerciseRepository 
 // Get retrieves a single exercise by ID.
 func (r *sqliteExerciseRepository) Get(ctx context.Context, id int) (Exercise, error) {
 	var exercise Exercise
+	var defaultStartingSeconds sql.NullInt64
 
 	err := r.db.ReadOnly.QueryRowContext(ctx, `
-		SELECT id, name, category, exercise_type, description_markdown
+		SELECT id, name, category, exercise_type, description_markdown, default_starting_seconds
 		FROM exercises
 		WHERE id = ?`, id).Scan(
 		&exercise.ID,
@@ -34,9 +35,14 @@ func (r *sqliteExerciseRepository) Get(ctx context.Context, id int) (Exercise, e
 		&exercise.Category,
 		&exercise.ExerciseType,
 		&exercise.DescriptionMarkdown,
+		&defaultStartingSeconds,
 	)
 	if err != nil {
 		return Exercise{}, fmt.Errorf("query exercise: %w", err)
+	}
+	if defaultStartingSeconds.Valid {
+		v := int(defaultStartingSeconds.Int64)
+		exercise.DefaultStartingSeconds = &v
 	}
 
 	// Fetch muscle groups
@@ -53,9 +59,9 @@ func (r *sqliteExerciseRepository) Get(ctx context.Context, id int) (Exercise, e
 
 // ListExercises returns all available exercises with their muscle groups.
 func (r *sqliteExerciseRepository) List(ctx context.Context) (_ []Exercise, err error) {
-	// First, get all exercises
+	// First, get all exercises.
 	rows, err := r.db.ReadOnly.QueryContext(ctx, `
-		SELECT id, name, category, exercise_type, description_markdown
+		SELECT id, name, category, exercise_type, description_markdown, default_starting_seconds
 		FROM exercises
 		ORDER BY id`)
 	if err != nil {
@@ -70,10 +76,16 @@ func (r *sqliteExerciseRepository) List(ctx context.Context) (_ []Exercise, err 
 	var exercises []Exercise
 	for rows.Next() {
 		var exercise Exercise
+		var defaultStartingSeconds sql.NullInt64
 		if err = rows.Scan(
-			&exercise.ID, &exercise.Name, &exercise.Category, &exercise.ExerciseType, &exercise.DescriptionMarkdown,
+			&exercise.ID, &exercise.Name, &exercise.Category, &exercise.ExerciseType,
+			&exercise.DescriptionMarkdown, &defaultStartingSeconds,
 		); err != nil {
 			return nil, fmt.Errorf("scan exercise: %w", err)
+		}
+		if defaultStartingSeconds.Valid {
+			v := int(defaultStartingSeconds.Int64)
+			exercise.DefaultStartingSeconds = &v
 		}
 		exercises = append(exercises, exercise)
 	}

--- a/internal/workout/repository-exercises.go
+++ b/internal/workout/repository-exercises.go
@@ -200,6 +200,11 @@ func (r *sqliteExerciseRepository) Update(
 
 // set creates or updates an exercise with optional upsert.
 func (r *sqliteExerciseRepository) set(ctx context.Context, ex Exercise, upsert bool) (_ Exercise, err error) {
+	// time_based exercises currently cannot be created or updated through this
+	// path: default_starting_seconds is not written, so the schema CHECK
+	// (exercise_type <> 'time_based' OR default_starting_seconds IS NOT NULL)
+	// fails. Task 9 (admin form support) will add the column to both INSERTs.
+
 	// Begin transaction
 	tx, err := r.db.ReadWrite.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/workout/repository-sessions.go
+++ b/internal/workout/repository-sessions.go
@@ -304,9 +304,8 @@ type loadExerciseSetsRow struct {
 	warmupCompletedAtStr sql.NullString
 	setNumber            sql.NullInt32
 	weightKg             sql.NullFloat64
-	minReps              sql.NullInt32
-	maxReps              sql.NullInt32
-	completedReps        sql.NullInt32
+	targetValue          sql.NullInt32
+	completedValue       sql.NullInt32
 	completedAtStr       sql.NullString
 	signalStr            sql.NullString
 }
@@ -324,8 +323,8 @@ func (r *sqliteSessionRepository) loadExerciseSets(
 
 	rows, err := q.QueryContext(ctx, `
 		SELECT we.id, we.exercise_id, we.warmup_completed_at,
-		       es.set_number, es.weight_kg, es.min_reps, es.max_reps,
-		       es.completed_reps, es.completed_at, es.signal
+		       es.set_number, es.weight_kg, es.target_value,
+		       es.completed_value, es.completed_at, es.signal
 		FROM workout_exercise we
 		LEFT JOIN exercise_sets es ON es.workout_exercise_id = we.id
 		WHERE we.workout_user_id = ? AND we.workout_date = ?
@@ -353,8 +352,8 @@ func (r *sqliteSessionRepository) loadExerciseSets(
 	for rows.Next() {
 		var row loadExerciseSetsRow
 		if err = rows.Scan(&row.weID, &row.exerciseID, &row.warmupCompletedAtStr,
-			&row.setNumber, &row.weightKg, &row.minReps, &row.maxReps,
-			&row.completedReps, &row.completedAtStr, &row.signalStr); err != nil {
+			&row.setNumber, &row.weightKg, &row.targetValue,
+			&row.completedValue, &row.completedAtStr, &row.signalStr); err != nil {
 			return nil, fmt.Errorf("scan exercise set: %w", err)
 		}
 
@@ -404,17 +403,16 @@ func (r *sqliteSessionRepository) startAggregate(row loadExerciseSetsRow) (exerc
 
 // buildSet materialises a Set from a row that has set_number populated.
 func (r *sqliteSessionRepository) buildSet(row loadExerciseSetsRow) (Set, error) {
-	set := Set{ //nolint:exhaustruct // CompletedReps, CompletedAt, Signal are populated below.
-		MinReps: int(row.minReps.Int32),
-		MaxReps: int(row.maxReps.Int32),
+	set := Set{ //nolint:exhaustruct // CompletedValue, CompletedAt, Signal are populated below.
+		TargetValue: int(row.targetValue.Int32),
 	}
 	if row.weightKg.Valid {
 		w := row.weightKg.Float64
 		set.WeightKg = &w
 	}
-	if row.completedReps.Valid {
-		c := int(row.completedReps.Int32)
-		set.CompletedReps = &c
+	if row.completedValue.Valid {
+		c := int(row.completedValue.Int32)
+		set.CompletedValue = &c
 	}
 	if err := r.parseCompletedAtTimestamp(row.completedAtStr, &set); err != nil {
 		return Set{}, err
@@ -470,8 +468,8 @@ func (r *sqliteSessionRepository) ListSetsForExerciseSince(
 	sinceDateStr := formatDate(sinceDate)
 
 	rows, err := r.db.ReadOnly.QueryContext(ctx, `
-		SELECT we.workout_date, es.weight_kg, es.min_reps, es.max_reps,
-		       es.completed_reps, es.completed_at, we.warmup_completed_at, es.signal
+		SELECT we.workout_date, es.weight_kg, es.target_value,
+		       es.completed_value, es.completed_at, we.warmup_completed_at, es.signal
 		FROM workout_exercise we
 		JOIN exercise_sets es ON es.workout_exercise_id = we.id
 		WHERE we.workout_user_id = ? AND we.exercise_id = ? AND we.workout_date >= ?
@@ -564,7 +562,7 @@ func (r *sqliteSessionRepository) GetLatestStartingWeightBefore(
 		WHERE we.workout_user_id = ?
 		  AND we.exercise_id = ?
 		  AND we.workout_date < ?
-		  AND es.completed_reps IS NOT NULL
+		  AND es.completed_value IS NOT NULL
 		  AND es.weight_kg IS NOT NULL
 		  AND es.signal IN ('on_target', 'too_light') -- NULL signals are excluded intentionally.
 		ORDER BY we.workout_date DESC, es.set_number DESC
@@ -594,8 +592,8 @@ func (r *sqliteSessionRepository) scanExerciseSetWithDate(
 		warmupCompletedAtStr sql.NullString
 		signalStr            sql.NullString
 	)
-	if err := rows.Scan(&workoutDateStr, &set.WeightKg, &set.MinReps, &set.MaxReps,
-		&set.CompletedReps, &completedAtStr, &warmupCompletedAtStr, &signalStr); err != nil {
+	if err := rows.Scan(&workoutDateStr, &set.WeightKg, &set.TargetValue,
+		&set.CompletedValue, &completedAtStr, &warmupCompletedAtStr, &signalStr); err != nil {
 		return "", Set{}, sql.NullString{}, fmt.Errorf("scan exercise set row: %w", err)
 	}
 	if err := r.parseCompletedAtTimestamp(completedAtStr, &set); err != nil {
@@ -721,10 +719,10 @@ func (r *sqliteSessionRepository) saveExerciseSets(
 			if _, err = tx.ExecContext(ctx, `
 				INSERT INTO exercise_sets (
 					workout_exercise_id, set_number,
-					weight_kg, min_reps, max_reps, completed_reps, completed_at, signal
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+					weight_kg, target_value, completed_value, completed_at, signal
+				) VALUES (?, ?, ?, ?, ?, ?, ?)`,
 				weID, i+1,
-				set.WeightKg, set.MinReps, set.MaxReps, set.CompletedReps, completedAtStr, signalValue); err != nil {
+				set.WeightKg, set.TargetValue, set.CompletedValue, completedAtStr, signalValue); err != nil {
 				return fmt.Errorf("insert exercise set: %w", err)
 			}
 		}

--- a/internal/workout/repository-sessions.go
+++ b/internal/workout/repository-sessions.go
@@ -581,6 +581,39 @@ func (r *sqliteSessionRepository) GetLatestStartingWeightBefore(
 	}, nil
 }
 
+// GetLatestSuccessfulSecondsBefore returns the completed_value of the latest
+// successful set for the given time-based exercise from a session strictly
+// before beforeDate. A set is "successful" when completed_value IS NOT NULL
+// and signal is 'on_target' or 'too_light'. Returns 0 when no successful
+// history exists.
+func (r *sqliteSessionRepository) GetLatestSuccessfulSecondsBefore(
+	ctx context.Context,
+	exerciseID int,
+	beforeDate time.Time,
+) (int, error) {
+	userID := contexthelpers.AuthenticatedUserID(ctx)
+	var seconds int
+	err := r.db.ReadOnly.QueryRowContext(ctx, `
+		SELECT es.completed_value
+		FROM exercise_sets es
+		JOIN workout_exercise we ON we.id = es.workout_exercise_id
+		WHERE we.workout_user_id = ?
+		  AND we.exercise_id = ?
+		  AND we.workout_date < ?
+		  AND es.completed_value IS NOT NULL
+		  AND es.signal IN ('on_target', 'too_light')
+		ORDER BY we.workout_date DESC, es.set_number DESC
+		LIMIT 1`,
+		userID, exerciseID, formatDate(beforeDate)).Scan(&seconds)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("query latest successful seconds: %w", err)
+	}
+	return seconds, nil
+}
+
 // scanExerciseSetWithDate scans one row from the ListSetsForExerciseSince query.
 func (r *sqliteSessionRepository) scanExerciseSetWithDate(
 	rows *sql.Rows,

--- a/internal/workout/repository.go
+++ b/internal/workout/repository.go
@@ -75,6 +75,12 @@ type sessionRepository interface {
 	// strictly before beforeDate, along with that session's periodization type.
 	// Returns a zero-value struct when no successful history exists.
 	GetLatestStartingWeightBefore(ctx context.Context, exerciseID int, beforeDate time.Time) (LatestStartingSet, error)
+	// GetLatestSuccessfulSecondsBefore returns the completed_value of the latest
+	// successful set for the given time-based exercise from a session strictly
+	// before beforeDate. A set is "successful" when completed_value IS NOT NULL
+	// and signal is 'on_target' or 'too_light'. Returns 0 when no successful
+	// history exists.
+	GetLatestSuccessfulSecondsBefore(ctx context.Context, exerciseID int, beforeDate time.Time) (int, error)
 	// CountCompleted returns the count of sessions with completed_at IS NOT NULL.
 	CountCompleted(ctx context.Context) (int, error)
 	// CreateBatch creates multiple sessions atomically in a single transaction.

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -674,6 +674,57 @@ func (s *Service) BuildProgression(
 	return exerciseprogression.NewFromHistory(config, completed), nil
 }
 
+// BuildTimedProgression constructs an exerciseprogression.TimedProgression
+// for the given time-based exercise in the given session, ready to call
+// CurrentSet() for the next hold's recommendation. Returns an error if the
+// exercise is not time_based or if the lookup fails.
+func (s *Service) BuildTimedProgression(
+	ctx context.Context,
+	date time.Time,
+	exerciseID int,
+) (*exerciseprogression.TimedProgression, error) {
+	starting, err := s.GetStartingSeconds(ctx, exerciseID, date)
+	if err != nil {
+		return nil, fmt.Errorf("get starting seconds: %w", err)
+	}
+
+	sess, err := s.repo.sessions.Get(ctx, date)
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+
+	var completed []exerciseprogression.TimedSetResult
+	for _, es := range sess.ExerciseSets {
+		if es.ExerciseID != exerciseID {
+			continue
+		}
+		for _, set := range es.Sets {
+			if set.CompletedValue == nil || set.Signal == nil {
+				continue
+			}
+			var sig exerciseprogression.Signal
+			switch *set.Signal {
+			case SignalTooHeavy:
+				sig = exerciseprogression.SignalTooHeavy
+			case SignalOnTarget:
+				sig = exerciseprogression.SignalOnTarget
+			case SignalTooLight:
+				sig = exerciseprogression.SignalTooLight
+			}
+			completed = append(completed, exerciseprogression.TimedSetResult{
+				ActualSeconds: *set.CompletedValue,
+				Signal:        sig,
+			})
+		}
+		break
+	}
+
+	return exerciseprogression.NewTimedFromHistory(
+		exerciseprogression.TimedConfig{StartingSeconds: starting},
+		completed,
+	), nil
+}
+
 // UpdateExercise updates an existing exercise.
 func (s *Service) UpdateExercise(ctx context.Context, ex Exercise) error {
 	if err := s.repo.exercises.Update(ctx, ex.ID, func(oldEx *Exercise) (bool, error) {

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -195,9 +195,8 @@ func (s *Service) generateWeeklyPlan(ctx context.Context, monday time.Time) erro
 		for j, pes := range ps.ExerciseSets {
 			sets := make([]Set, len(pes.Sets))
 			for k, planSet := range pes.Sets {
-				sets[k] = Set{ //nolint:exhaustruct // WeightKg, CompletedReps, CompletedAt, Signal start nil.
-					MinReps: planSet.MinReps,
-					MaxReps: planSet.MaxReps,
+				sets[k] = Set{ //nolint:exhaustruct // WeightKg, CompletedValue, CompletedAt, Signal start nil.
+					TargetValue: planSet.TargetValue,
 				}
 			}
 			exerciseSets[j] = exerciseSetAggregate{ //nolint:exhaustruct // ID is auto-assigned, WarmupCompletedAt starts nil.
@@ -358,13 +357,13 @@ func (s *Service) UpdateSetWeight(
 	return nil
 }
 
-// UpdateCompletedReps updates a previously completed set with new rep count.
-func (s *Service) UpdateCompletedReps(
+// UpdateCompletedValue updates a previously completed set with new value (reps or seconds).
+func (s *Service) UpdateCompletedValue(
 	ctx context.Context,
 	date time.Time,
 	workoutExerciseID int,
 	setIndex int,
-	completedReps int,
+	completedValue int,
 ) error {
 	if err := s.repo.sessions.Update(ctx, date, func(sess *sessionAggregate) (bool, error) {
 		for _, ex := range sess.ExerciseSets {
@@ -373,7 +372,7 @@ func (s *Service) UpdateCompletedReps(
 					return false, fmt.Errorf("exercise set index %d out of bounds", setIndex)
 				}
 				now := time.Now().UTC()
-				ex.Sets[setIndex].CompletedReps = &completedReps
+				ex.Sets[setIndex].CompletedValue = &completedValue
 				ex.Sets[setIndex].CompletedAt = &now
 				return true, nil
 			}
@@ -405,7 +404,7 @@ func (s *Service) RecordSetCompletion(
 				now := time.Now().UTC()
 				sess.ExerciseSets[i].Sets[setIndex].Signal = &signal
 				sess.ExerciseSets[i].Sets[setIndex].WeightKg = &weightKg
-				sess.ExerciseSets[i].Sets[setIndex].CompletedReps = &reps
+				sess.ExerciseSets[i].Sets[setIndex].CompletedValue = &reps
 				sess.ExerciseSets[i].Sets[setIndex].CompletedAt = &now
 				return true, nil
 			}
@@ -528,7 +527,7 @@ func (s *Service) GetExerciseSetsForExerciseSince(ctx context.Context, exerciseI
 		// Collect only completed sets; skip entries with none.
 		var completedSets []Set
 		for _, set := range agg.Sets {
-			if set.CompletedReps != nil {
+			if set.CompletedValue != nil {
 				completedSets = append(completedSets, set)
 			}
 		}
@@ -615,7 +614,7 @@ func (s *Service) BuildProgression(
 			continue
 		}
 		for _, set := range es.Sets {
-			if set.CompletedReps == nil || set.Signal == nil {
+			if set.CompletedValue == nil || set.Signal == nil {
 				continue
 			}
 			var sig exerciseprogression.Signal
@@ -632,7 +631,7 @@ func (s *Service) BuildProgression(
 				kg = *set.WeightKg
 			}
 			completed = append(completed, exerciseprogression.SetResult{
-				ActualReps: *set.CompletedReps,
+				ActualReps: *set.CompletedValue,
 				Signal:     sig,
 				WeightKg:   kg,
 			})
@@ -804,7 +803,7 @@ func (s *Service) generateExerciseContent(ctx context.Context, name string) Exer
 
 // createMinimalExercise returns a basic exercise with just the essential fields populated.
 func createMinimalExercise(name string) Exercise {
-	return Exercise{
+	return Exercise{ //nolint:exhaustruct // DefaultStartingSeconds is nil for non-time_based exercises.
 		ID:                    -1,
 		Name:                  name,
 		Category:              CategoryFullBody,
@@ -873,17 +872,16 @@ func (s *Service) findHistoricalSets(ctx context.Context, date time.Time, exerci
 	return nil, nil
 }
 
-// copySetsWithoutCompletion creates a copy of sets with completed reps reset to nil.
+// copySetsWithoutCompletion creates a copy of sets with completion reset to nil.
 func (s *Service) copySetsWithoutCompletion(sets []Set) []Set {
 	result := make([]Set, len(sets))
 	for i, set := range sets {
 		result[i] = Set{
-			WeightKg:      set.WeightKg,
-			MinReps:       set.MinReps,
-			MaxReps:       set.MaxReps,
-			CompletedReps: nil, // Reset completion status
-			CompletedAt:   nil,
-			Signal:        nil,
+			WeightKg:       set.WeightKg,
+			TargetValue:    set.TargetValue,
+			CompletedValue: nil, // Reset completion status.
+			CompletedAt:    nil,
+			Signal:         nil,
 		}
 	}
 	return result
@@ -895,15 +893,14 @@ func (s *Service) createEmptySets(templateSets []Set) []Set {
 	for i, set := range templateSets {
 		var weight *float64
 		if set.WeightKg != nil {
-			weight = new(float64) // Empty weight for weighted exercises
+			weight = new(float64) // Empty weight for weighted exercises.
 		}
 		result[i] = Set{
-			WeightKg:      weight,
-			MinReps:       set.MinReps,
-			MaxReps:       set.MaxReps,
-			CompletedReps: nil,
-			CompletedAt:   nil,
-			Signal:        nil,
+			WeightKg:       weight,
+			TargetValue:    set.TargetValue,
+			CompletedValue: nil,
+			CompletedAt:    nil,
+			Signal:         nil,
 		}
 	}
 	return result
@@ -962,11 +959,8 @@ func (s *Service) FindCompatibleExercises(ctx context.Context, exerciseID int) (
 	return otherExercises, nil
 }
 
-// Default rep ranges.
-const (
-	defaultMinReps = 8
-	defaultMaxReps = 12
-)
+// defaultTargetValue is the fallback target value (reps) when no history is available.
+const defaultTargetValue = 8
 
 // AddExercise adds a new exercise to an existing workout session.
 // It will retrieve historical weight data if available. Returns the
@@ -1014,12 +1008,11 @@ func (s *Service) AddExercise(ctx context.Context, date time.Time, exerciseID in
 			newSets = make([]Set, defaultSetCount)
 			for i := range newSets {
 				newSets[i] = Set{
-					WeightKg:      new(float64),
-					MinReps:       defaultMinReps,
-					MaxReps:       defaultMaxReps,
-					CompletedReps: nil,
-					CompletedAt:   nil,
-					Signal:        nil,
+					WeightKg:       new(float64),
+					TargetValue:    defaultTargetValue,
+					CompletedValue: nil,
+					CompletedAt:    nil,
+					Signal:         nil,
 				}
 			}
 		}

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -162,11 +162,12 @@ func (s *Service) generateWeeklyPlan(ctx context.Context, monday time.Time) erro
 	wpExercises := make([]weekplanner.Exercise, len(exercises))
 	for i, ex := range exercises {
 		wpExercises[i] = weekplanner.Exercise{
-			ID:                    ex.ID,
-			Category:              weekplanner.Category(ex.Category),
-			ExerciseType:          weekplanner.ExerciseType(ex.ExerciseType),
-			PrimaryMuscleGroups:   ex.PrimaryMuscleGroups,
-			SecondaryMuscleGroups: ex.SecondaryMuscleGroups,
+			ID:                     ex.ID,
+			Category:               weekplanner.Category(ex.Category),
+			ExerciseType:           weekplanner.ExerciseType(ex.ExerciseType),
+			PrimaryMuscleGroups:    ex.PrimaryMuscleGroups,
+			SecondaryMuscleGroups:  ex.SecondaryMuscleGroups,
+			DefaultStartingSeconds: ex.DefaultStartingSeconds,
 		}
 	}
 

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -417,6 +417,37 @@ func (s *Service) RecordSetCompletion(
 	return nil
 }
 
+// RecordTimedSetCompletion atomically persists the signal, completed seconds,
+// and timestamp for a time-based set. Mirrors RecordSetCompletion but omits
+// weight (time-based exercises have no weight).
+func (s *Service) RecordTimedSetCompletion(
+	ctx context.Context,
+	date time.Time,
+	workoutExerciseID int,
+	setIndex int,
+	signal Signal,
+	completedSeconds int,
+) error {
+	if err := s.repo.sessions.Update(ctx, date, func(sess *sessionAggregate) (bool, error) {
+		for i := range sess.ExerciseSets {
+			if sess.ExerciseSets[i].ID == workoutExerciseID {
+				if setIndex >= len(sess.ExerciseSets[i].Sets) {
+					return false, fmt.Errorf("set index %d out of bounds", setIndex)
+				}
+				now := time.Now().UTC()
+				sess.ExerciseSets[i].Sets[setIndex].Signal = &signal
+				sess.ExerciseSets[i].Sets[setIndex].CompletedValue = &completedSeconds
+				sess.ExerciseSets[i].Sets[setIndex].CompletedAt = &now
+				return true, nil
+			}
+		}
+		return false, errors.New("workout exercise not found")
+	}); err != nil {
+		return fmt.Errorf("update session %s: %w", formatDate(date), err)
+	}
+	return nil
+}
+
 // MarkWarmupComplete marks the warmup as complete for a specific workout exercise slot.
 func (s *Service) MarkWarmupComplete(
 	ctx context.Context,

--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -571,6 +571,38 @@ func (s *Service) GetStartingWeight(
 	return exerciseprogression.ConvertWeight(prev.WeightKg, fromReps, toReps), nil
 }
 
+// GetStartingSeconds returns the seconds target to seed a new session for
+// the given time-based exercise. Pulls the latest successful set's
+// completed_value from sessions strictly before beforeDate; falls back to
+// the exercise's DefaultStartingSeconds when no successful history exists.
+// Returns an error if the exercise is not time_based, if the lookup fails,
+// or if a time_based exercise has no DefaultStartingSeconds (which is a
+// fixture/data invariant violation since the schema CHECK requires it).
+func (s *Service) GetStartingSeconds(
+	ctx context.Context,
+	exerciseID int,
+	beforeDate time.Time,
+) (int, error) {
+	exercise, err := s.repo.exercises.Get(ctx, exerciseID)
+	if err != nil {
+		return 0, fmt.Errorf("get exercise: %w", err)
+	}
+	if !exercise.IsTimed() {
+		return 0, fmt.Errorf("exercise %d is not time_based", exerciseID)
+	}
+	seconds, err := s.repo.sessions.GetLatestSuccessfulSecondsBefore(ctx, exerciseID, beforeDate)
+	if err != nil {
+		return 0, fmt.Errorf("get latest successful seconds: %w", err)
+	}
+	if seconds > 0 {
+		return seconds, nil
+	}
+	if exercise.DefaultStartingSeconds == nil {
+		return 0, fmt.Errorf("time_based exercise %d has no default_starting_seconds", exerciseID)
+	}
+	return *exercise.DefaultStartingSeconds, nil
+}
+
 // periodizationToProgression maps a workout periodization to its exerciseprogression
 // counterpart. Unknown values default to Strength.
 func periodizationToProgression(p PeriodizationType) exerciseprogression.PeriodizationType {

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -1262,6 +1262,95 @@ func Test_GetStartingSeconds(t *testing.T) {
 	}
 }
 
+func Test_BuildTimedProgression(t *testing.T) {
+	ctx := t.Context()
+	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))
+	db, err := sqlite.NewDatabase(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var userID int
+	if err = db.ReadWrite.QueryRowContext(ctx,
+		"INSERT INTO users (webauthn_user_id, display_name) VALUES (?, ?) RETURNING id",
+		[]byte("btp-user"), "BTP User").Scan(&userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
+	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
+
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO exercises (name, category, exercise_type, default_starting_seconds, description_markdown)
+		VALUES (?, ?, ?, ?, ?)`,
+		"Test Plank BTP", "upper", "time_based", 30, ""); err != nil {
+		t.Fatalf("insert exercise: %v", err)
+	}
+	var exerciseID int
+	if err = db.ReadOnly.QueryRowContext(ctx,
+		"SELECT id FROM exercises WHERE name = 'Test Plank BTP'").Scan(&exerciseID); err != nil {
+		t.Fatalf("get exercise id: %v", err)
+	}
+
+	svc := workout.NewService(db, logger, "")
+
+	today := time.Now().Format("2006-01-02")
+	todayTime, _ := time.Parse("2006-01-02", today)
+
+	// Seed today's session with the exercise but no completed sets yet.
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO workout_sessions (user_id, workout_date, periodization_type)
+		VALUES (?, ?, 'strength')`, userID, today); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	var weID int
+	if err = db.ReadWrite.QueryRowContext(ctx, `
+		INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id)
+		VALUES (?, ?, ?) RETURNING id`,
+		userID, today, exerciseID).Scan(&weID); err != nil {
+		t.Fatalf("insert workout_exercise: %v", err)
+	}
+	// Seed three planned sets with target_value=30, no completion yet.
+	for i := 1; i <= 3; i++ {
+		if _, err = db.ReadWrite.ExecContext(ctx, `
+			INSERT INTO exercise_sets (workout_exercise_id, set_number, target_value)
+			VALUES (?, ?, 30)`, weID, i); err != nil {
+			t.Fatalf("insert set %d: %v", i, err)
+		}
+	}
+
+	// Case 1: no completed sets in this session → first set returns starting seconds (default 30).
+	progression, err := svc.BuildTimedProgression(ctx, todayTime, exerciseID)
+	if err != nil {
+		t.Fatalf("BuildTimedProgression no completion: %v", err)
+	}
+	if got := progression.CurrentSet().TargetSeconds; got != 30 {
+		t.Errorf("first set: got %d, want 30 (default)", got)
+	}
+	if got := progression.SetsCompleted(); got != 0 {
+		t.Errorf("first set: SetsCompleted = %d, want 0", got)
+	}
+
+	// Case 2: complete set 1 with too_light → second set should be 35s.
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		UPDATE exercise_sets
+		SET completed_value = 30, signal = 'too_light'
+		WHERE workout_exercise_id = ? AND set_number = 1`, weID); err != nil {
+		t.Fatalf("update set 1: %v", err)
+	}
+
+	progression, err = svc.BuildTimedProgression(ctx, todayTime, exerciseID)
+	if err != nil {
+		t.Fatalf("BuildTimedProgression after set 1: %v", err)
+	}
+	if got := progression.CurrentSet().TargetSeconds; got != 35 {
+		t.Errorf("after too_light: got %d, want 35", got)
+	}
+	if got := progression.SetsCompleted(); got != 1 {
+		t.Errorf("after set 1: SetsCompleted = %d, want 1", got)
+	}
+}
+
 func Test_RecordSetCompletion(t *testing.T) {
 	ctx := t.Context()
 	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -230,14 +230,12 @@ func Test_WeeklyMuscleGroupVolume_AggregatesPrimaryAndSecondary(t *testing.T) {
 	}
 
 	completed := time.Now().UTC()
-	completedSet := workout.Set{ //nolint:exhaustruct // Reps and weight are not relevant for volume.
-		MinReps:     8,
-		MaxReps:     12,
+	completedSet := workout.Set{ //nolint:exhaustruct // Value and weight are not relevant for volume.
+		TargetValue: 12,
 		CompletedAt: &completed,
 	}
 	plannedSet := workout.Set{ //nolint:exhaustruct // CompletedAt nil → planned but not completed.
-		MinReps: 8,
-		MaxReps: 12,
+		TargetValue: 12,
 	}
 
 	benchSet := workout.ExerciseSet{ //nolint:exhaustruct // ID + WarmupCompletedAt are repository-managed.
@@ -423,9 +421,9 @@ func Test_UpdateExercise_PreservesExerciseSets(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets
-		(workout_exercise_id, set_number, weight_kg, min_reps, max_reps)
-		VALUES (?, ?, ?, ?, ?)`,
-		weID, 1, 50.0, 8, 12)
+		(workout_exercise_id, set_number, weight_kg, target_value)
+		VALUES (?, ?, ?, ?)`,
+		weID, 1, 50.0, 12)
 	if err != nil {
 		t.Fatalf("Failed to insert exercise set: %v", err)
 	}
@@ -443,7 +441,7 @@ func Test_UpdateExercise_PreservesExerciseSets(t *testing.T) {
 	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
 	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
 
-	updatedExercise := workout.Exercise{
+	updatedExercise := workout.Exercise{ //nolint:exhaustruct // DefaultStartingSeconds not needed for this test.
 		ID:                    exerciseID,
 		Name:                  "Updated Test Exercise",
 		Category:              workout.CategoryLower,
@@ -564,9 +562,9 @@ func Test_AddExercise(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets
-		(workout_exercise_id, set_number, weight_kg, min_reps, max_reps)
-		VALUES (?, ?, ?, ?, ?)`,
-		weID1, 1, 50.0, 8, 12)
+		(workout_exercise_id, set_number, weight_kg, target_value)
+		VALUES (?, ?, ?, ?)`,
+		weID1, 1, 50.0, 12)
 	if err != nil {
 		t.Fatalf("Failed to insert exercise set: %v", err)
 	}
@@ -734,8 +732,8 @@ func Test_AddExercise_UsesMostRecentHistoricalWeight(t *testing.T) {
 			t.Fatalf("insert workout_exercise %d days ago: %v", daysAgo, err)
 		}
 		if _, err = db.ReadWrite.ExecContext(ctx,
-			`INSERT INTO exercise_sets (workout_exercise_id, set_number, weight_kg, min_reps, max_reps)
-			 VALUES (?, 1, ?, 8, 12)`,
+			`INSERT INTO exercise_sets (workout_exercise_id, set_number, weight_kg, target_value)
+			 VALUES (?, 1, ?, 12)`,
 			weID, weight); err != nil {
 			t.Fatalf("insert exercise_set %d days ago: %v", daysAgo, err)
 		}
@@ -975,10 +973,10 @@ func Test_GetStartingWeight(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-		 weight_kg, min_reps, max_reps, completed_reps, signal)
-		 VALUES (?, 1, 95.0, 5, 5, 5, 'too_light'),
-		        (?, 2, 100.0, 5, 5, 5, 'on_target'),
-		        (?, 3, 105.0, 5, 5, 3, 'too_heavy')`,
+		 weight_kg, target_value, completed_value, signal)
+		 VALUES (?, 1, 95.0, 5, 5, 'too_light'),
+		        (?, 2, 100.0, 5, 5, 'on_target'),
+		        (?, 3, 105.0, 5, 3, 'too_heavy')`,
 		weHistID, weHistID, weHistID)
 	if err != nil {
 		t.Fatalf("insert sets: %v", err)
@@ -1022,9 +1020,9 @@ func Test_GetStartingWeight(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-		 weight_kg, min_reps, max_reps, completed_reps, signal)
-		 VALUES (?, 1, 75.0, 5, 5, 5, 'too_light'),
-		        (?, 2, 80.0, 5, 5, 5, 'on_target')`,
+		 weight_kg, target_value, completed_value, signal)
+		 VALUES (?, 1, 75.0, 5, 5, 'too_light'),
+		        (?, 2, 80.0, 5, 5, 'on_target')`,
 		weTodayID, weTodayID)
 	if err != nil {
 		t.Fatalf("insert today's sets: %v", err)
@@ -1058,9 +1056,9 @@ func Test_GetStartingWeight(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-		 weight_kg, min_reps, max_reps, completed_reps, signal)
-		 VALUES (?, 1, 110.0, 5, 5, 3, 'too_heavy'),
-		        (?, 2, 110.0, 5, 5, 2, 'too_heavy')`,
+		 weight_kg, target_value, completed_value, signal)
+		 VALUES (?, 1, 110.0, 5, 3, 'too_heavy'),
+		        (?, 2, 110.0, 5, 2, 'too_heavy')`,
 		weFailID, weFailID)
 	if err != nil {
 		t.Fatalf("insert fail sets: %v", err)
@@ -1134,8 +1132,8 @@ func Test_GetStartingWeight_Assisted(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-		 weight_kg, min_reps, max_reps, completed_reps, signal)
-		 VALUES (?, 1, -50.0, 5, 5, 5, 'on_target')`,
+		 weight_kg, target_value, completed_value, signal)
+		 VALUES (?, 1, -50.0, 5, 5, 'on_target')`,
 		weHistID)
 	if err != nil {
 		t.Fatalf("insert sets: %v", err)
@@ -1204,8 +1202,8 @@ func Test_RecordSetCompletion(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-		 weight_kg, min_reps, max_reps)
-		 VALUES (?, 1, 100.0, 5, 5)`,
+		 weight_kg, target_value)
+		 VALUES (?, 1, 100.0, 5)`,
 		weID)
 	if err != nil {
 		t.Fatalf("insert set: %v", err)
@@ -1241,8 +1239,8 @@ func Test_RecordSetCompletion(t *testing.T) {
 	if set.WeightKg == nil || *set.WeightKg != 102.5 {
 		t.Errorf("weight: want 102.5, got %v", set.WeightKg)
 	}
-	if set.CompletedReps == nil || *set.CompletedReps != 5 {
-		t.Errorf("reps: want 5, got %v", set.CompletedReps)
+	if set.CompletedValue == nil || *set.CompletedValue != 5 {
+		t.Errorf("completed value: want 5, got %v", set.CompletedValue)
 	}
 	if set.CompletedAt == nil {
 		t.Error("completed_at: want non-nil")
@@ -1297,8 +1295,8 @@ func Test_BuildProgression(t *testing.T) {
 		t.Fatalf("insert workout_exercise: %v", err)
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
-		`INSERT INTO exercise_sets (workout_exercise_id, set_number, weight_kg, min_reps, max_reps)
-		 VALUES (?, 1, 40.0, 8, 8), (?, 2, 40.0, 8, 8), (?, 3, 40.0, 8, 8)`,
+		`INSERT INTO exercise_sets (workout_exercise_id, set_number, weight_kg, target_value)
+		 VALUES (?, 1, 40.0, 8), (?, 2, 40.0, 8), (?, 3, 40.0, 8)`,
 		weID, weID, weID)
 	if err != nil {
 		t.Fatalf("insert sets: %v", err)
@@ -1385,8 +1383,8 @@ func Test_BuildProgression_CrossPeriodizationConversion(t *testing.T) {
 	}
 	_, err = db.ReadWrite.ExecContext(ctx,
 		`INSERT INTO exercise_sets (workout_exercise_id, set_number,
-		 weight_kg, min_reps, max_reps, completed_reps, signal)
-		 VALUES (?, 1, 100.0, 5, 5, 5, 'on_target')`,
+		 weight_kg, target_value, completed_value, signal)
+		 VALUES (?, 1, 100.0, 5, 5, 'on_target')`,
 		wePrevID)
 	if err != nil {
 		t.Fatalf("insert prev set: %v", err)

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -1160,6 +1160,108 @@ func Test_GetStartingWeight_Assisted(t *testing.T) {
 	}
 }
 
+func Test_GetStartingSeconds(t *testing.T) {
+	ctx := t.Context()
+	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))
+	db, err := sqlite.NewDatabase(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var userID int
+	if err = db.ReadWrite.QueryRowContext(ctx,
+		"INSERT INTO users (webauthn_user_id, display_name) VALUES (?, ?) RETURNING id",
+		[]byte("ts-user"), "TS User").Scan(&userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
+	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
+
+	// Insert a time_based exercise with default 30s.
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO exercises (name, category, exercise_type, default_starting_seconds, description_markdown)
+		VALUES (?, ?, ?, ?, ?)`,
+		"Test Plank", "upper", "time_based", 30, ""); err != nil {
+		t.Fatalf("insert exercise: %v", err)
+	}
+	var exerciseID int
+	if err = db.ReadOnly.QueryRowContext(ctx,
+		"SELECT id FROM exercises WHERE name = 'Test Plank'").Scan(&exerciseID); err != nil {
+		t.Fatalf("get exercise id: %v", err)
+	}
+
+	svc := workout.NewService(db, logger, "")
+	today := time.Now()
+
+	// Case 1: no history → fallback to default_starting_seconds.
+	got, err := svc.GetStartingSeconds(ctx, exerciseID, today)
+	if err != nil {
+		t.Fatalf("no history: %v", err)
+	}
+	if got != 30 {
+		t.Errorf("no history: want 30, got %d", got)
+	}
+
+	// Case 2: seed a successful session 2 days ago.
+	twoDaysAgo := today.AddDate(0, 0, -2).Format("2006-01-02")
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO workout_sessions (user_id, workout_date, periodization_type)
+		VALUES (?, ?, 'strength')`, userID, twoDaysAgo); err != nil {
+		t.Fatalf("insert session 1: %v", err)
+	}
+	var weID1 int
+	if err = db.ReadWrite.QueryRowContext(ctx, `
+		INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id)
+		VALUES (?, ?, ?) RETURNING id`,
+		userID, twoDaysAgo, exerciseID).Scan(&weID1); err != nil {
+		t.Fatalf("insert workout_exercise 1: %v", err)
+	}
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO exercise_sets
+			(workout_exercise_id, set_number, target_value, completed_value, completed_at, signal)
+		VALUES (?, 1, 40, 40, '2026-05-05T12:00:00.000Z', 'on_target')`, weID1); err != nil {
+		t.Fatalf("insert set 1: %v", err)
+	}
+
+	got, err = svc.GetStartingSeconds(ctx, exerciseID, today)
+	if err != nil {
+		t.Fatalf("with history: %v", err)
+	}
+	if got != 40 {
+		t.Errorf("with history: want 40, got %d", got)
+	}
+
+	// Case 3: more recent too_heavy session should be skipped.
+	oneDayAgo := today.AddDate(0, 0, -1).Format("2006-01-02")
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO workout_sessions (user_id, workout_date, periodization_type)
+		VALUES (?, ?, 'strength')`, userID, oneDayAgo); err != nil {
+		t.Fatalf("insert session 2: %v", err)
+	}
+	var weID2 int
+	if err = db.ReadWrite.QueryRowContext(ctx, `
+		INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id)
+		VALUES (?, ?, ?) RETURNING id`,
+		userID, oneDayAgo, exerciseID).Scan(&weID2); err != nil {
+		t.Fatalf("insert workout_exercise 2: %v", err)
+	}
+	if _, err = db.ReadWrite.ExecContext(ctx, `
+		INSERT INTO exercise_sets
+			(workout_exercise_id, set_number, target_value, completed_value, completed_at, signal)
+		VALUES (?, 1, 50, 50, '2026-05-06T12:00:00.000Z', 'too_heavy')`, weID2); err != nil {
+		t.Fatalf("insert set 2: %v", err)
+	}
+
+	got, err = svc.GetStartingSeconds(ctx, exerciseID, today)
+	if err != nil {
+		t.Fatalf("skip too_heavy: %v", err)
+	}
+	if got != 40 {
+		t.Errorf("skip too_heavy: want 40 (older successful), got %d", got)
+	}
+}
+
 func Test_RecordSetCompletion(t *testing.T) {
 	ctx := t.Context()
 	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))

--- a/specs/05-time-based-exercises.md
+++ b/specs/05-time-based-exercises.md
@@ -1,0 +1,301 @@
+# Time-Based Exercise Type
+
+## Motivation
+
+Today the planner emits `min_reps`/`max_reps` for every exercise from a single
+per-session knob — `PeriodizationType` — yielding 5 reps for strength and 6–10
+for hypertrophy. For an isometric hold like plank, currently typed as
+`bodyweight` (`internal/sqlite/fixtures.sql:329`), this prescribes
+"5 plank reps" or "6–10 plank reps" — meaningless for a hold.
+
+The fix is to introduce a `time_based` exercise type whose sets carry a
+duration target instead of a rep count. The same Signal-driven auto-regulation
+that bumps weight up/down between weighted sets now bumps duration up/down
+between holds.
+
+## What we're adding
+
+- A fourth value, `time_based`, on the `exercises.exercise_type` CHECK enum.
+  Implies bodyweight (no `weight_kg`).
+- A schema collapse on `exercise_sets`:
+  `min_reps`/`max_reps`/`completed_reps` → `target_value`/`completed_value`.
+  The unit (reps vs seconds) is derived from the parent exercise's type. This
+  removes redundant data — the prior rep range was already a deterministic
+  function of `session.periodization_type` and was used purely for display
+  (`cmd/web/handler-exerciseset.go:36`); the progression engine in
+  `internal/exerciseprogression/progression.go:85` already operates on a
+  single integer target.
+- A new `default_starting_seconds` column on `exercises`, populated for
+  `time_based` rows. Lets the seed encode "plank starts at 30s for new users"
+  without code changes.
+- A parallel `TimedProgression` engine in `internal/exerciseprogression/`
+  mirroring the existing weighted `Progression`, with a second-step ladder
+  instead of a kg-step ladder.
+- A render-time helper `formatTarget(exercise, session, target)` that produces
+  the display string ("5", "6-10", "30s") in one place.
+- Plank's fixture row flips to `time_based` with `default_starting_seconds = 30`,
+  upserted via the existing `ON CONFLICT (name) DO UPDATE` clause in
+  `fixtures.sql`.
+
+## Key design decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Type axis | Add fourth `exercise_type` value `time_based` | Self-contained, simple, easy to migrate. Weighted timed holds are YAGNI. |
+| Unit storage | Single `target_value` column; unit from parent `exercise_type` | min/max-reps are display-only; planner+progression use a single integer. Collapsing removes redundant data and gives the future spec 01 per-exercise overrides one column to populate. |
+| Set-level unit flag | None | Sets inherit unit from the current exercise. Admin retypings are rare; if needed later we add a flag then. |
+| Migration of historical plank rows | Drop them | Pre-migration plank logged "5 reps" — meaningless. Reinterpreting as "5 seconds" misleads; carrying a per-set unit flag forever to handle one historical exercise is overkill. |
+| Migration strategy | One-shot premigration: CREATE+INSERT…SELECT+DROP+RENAME | Declarative migrator can't infer that `max_reps` becomes `target_value`. Standard pattern documented in `internal/sqlite/CLAUDE.md`. |
+| Progression model | Separate `TimedProgression` type | Two small focused engines beat one engine with a unit flag. Lets the second-step ladder diverge from the kg-step ladder freely. |
+| Signal | Reuse existing `Signal` enum | Auto-regulation works the same; the value being adjusted just happens to be seconds. |
+| Sets per exercise | 3 (unchanged) | Plank fits the existing 3-sets-per-exercise rhythm. |
+| Input format | Plain integer seconds | Plank/dead-hang holds rarely exceed 2 minutes. MM:SS adds parsing for no real gain. |
+| Time-based ranges | Single target, no min/max | Auto-regulation does the work between sets. Ranges add UI noise. |
+| First-session default | `default_starting_seconds` column on `exercises` | Users don't know what plank target to type on day one; weighted exercises don't have this problem because users know roughly what weight they can lift. |
+
+## Schema
+
+```sql
+-- exercises: add fourth exercise_type and default_starting_seconds
+exercise_type            TEXT NOT NULL DEFAULT 'weighted'
+                         CHECK (exercise_type IN ('weighted', 'bodyweight', 'assisted', 'time_based')),
+default_starting_seconds INTEGER CHECK (default_starting_seconds IS NULL OR default_starting_seconds > 0),
+-- time_based exercises must have a default; other types may leave it NULL.
+CHECK (exercise_type <> 'time_based' OR default_starting_seconds IS NOT NULL),
+
+-- exercise_sets: collapse min/max/reps into target/completed
+CREATE TABLE exercise_sets (
+    workout_exercise_id INTEGER NOT NULL REFERENCES workout_exercise (id) ON DELETE CASCADE,
+    set_number          INTEGER NOT NULL CHECK (set_number > 0),
+    weight_kg           REAL,
+    target_value        INTEGER NOT NULL CHECK (target_value > 0),
+    completed_value     INTEGER CHECK (completed_value IS NULL OR completed_value >= 0),
+    completed_at        TEXT CHECK (completed_at IS NULL OR
+                                    STRFTIME('%Y-%m-%dT%H:%M:%fZ', completed_at) = completed_at),
+    signal              TEXT CHECK (signal IS NULL OR signal IN ('too_heavy', 'on_target', 'too_light')),
+    PRIMARY KEY (workout_exercise_id, set_number)
+) WITHOUT ROWID, STRICT;
+```
+
+## Premigration
+
+`internal/sqlite/premigrate.go`, method `preMigrateExerciseSetTarget`, wired
+into `NewDatabase` between `connect` and `migrateTo`.
+
+1. Detect via `pragma_table_info('exercise_sets')` whether `target_value`
+   already exists; return early if so. Also early-return if `exercise_sets`
+   doesn't exist (fresh DB / in-memory test startup).
+2. `PRAGMA foreign_keys = OFF`. Begin transaction.
+3. Create `exercise_sets_new` matching the new shape.
+4. Translate:
+   ```sql
+   INSERT INTO exercise_sets_new
+       (workout_exercise_id, set_number, weight_kg, target_value,
+        completed_value, completed_at, signal)
+   SELECT s.workout_exercise_id, s.set_number, s.weight_kg,
+          s.max_reps, s.completed_reps, s.completed_at, s.signal
+     FROM exercise_sets s
+     JOIN workout_exercise wx ON wx.id = s.workout_exercise_id
+     JOIN exercises e         ON e.id = wx.exercise_id
+    WHERE e.name <> 'Plank';
+   ```
+5. `DROP TABLE exercise_sets; ALTER TABLE exercise_sets_new RENAME TO exercise_sets;`
+6. Commit. The declarative migrator's `migrateTo(schemaDefinition)` then
+   sees a database matching `schema.sql` and is a no-op for this table.
+
+Translation rules:
+
+- `target_value := max_reps` (top of the prescribed range; `completed_reps`
+  is what actually matters retrospectively).
+- `completed_value := completed_reps`.
+- `weight_kg`, `completed_at`, `signal` carried 1:1.
+- Plank rows dropped.
+
+Test in `migrate_internal_test.go`: define `legacyExerciseSetsSchema`
+reproducing the pre-migration shape, seed a hypertrophy bench row
+(min=6, max=10, completed=8) and a plank row, run the premigration, assert
+post-state, run again to prove idempotence, then call
+`migrateTo(schemaDefinition)` to confirm no-op.
+
+After this premigration runs in production, **delete the file, the call site,
+the test, and the legacy-schema constant in one commit** — same lifecycle as
+PR #75 (workout_exercise stable-id).
+
+## Domain model
+
+```go
+// internal/workout/models.go
+
+const ExerciseTypeTime ExerciseType = "time_based"
+
+type Exercise struct {
+    // ...existing fields...
+    DefaultStartingSeconds *int  // nullable; populated only for time_based
+}
+
+func (e Exercise) IsTimed() bool { return e.ExerciseType == ExerciseTypeTime }
+
+type Set struct {
+    WeightKg       *float64    // nil for bodyweight and time_based
+    TargetValue    int         // reps or seconds; unit from parent exercise
+    CompletedValue *int        // same unit as TargetValue
+    CompletedAt    *time.Time
+    Signal         *Signal
+}
+```
+
+`Set` deliberately doesn't carry the unit. Callers either have the parent
+exercise (handler/render path) or don't need the unit (generic
+persistence/aggregation).
+
+## Progression engine
+
+`internal/exerciseprogression/timed_progression.go` (new), parallel to
+`progression.go`:
+
+```go
+type TimedConfig struct {
+    StartingSeconds int  // caller-derived from history; default per-exercise on first session
+}
+
+type TimedSetTarget struct { TargetSeconds int }
+
+type TimedSetResult struct {
+    ActualSeconds int
+    Signal        Signal
+}
+
+type TimedProgression struct { /* config, completed slice */ }
+
+func NewTimed(c TimedConfig) *TimedProgression
+func NewTimedFromHistory(c TimedConfig, completed []TimedSetResult) *TimedProgression
+func (*TimedProgression) CurrentSet() TimedSetTarget
+func (*TimedProgression) RecordCompletion(TimedSetResult)
+func (*TimedProgression) SetsCompleted() int
+```
+
+Auto-regulation rules (mirrors the weighted decrement-factor pattern):
+
+- `SignalTooLight` → `current + incrementSeconds(current)`
+- `SignalOnTarget` → `current` unchanged
+- `SignalTooHeavy` → `max(5, current - max(incrementSeconds(current), snap5(current * 0.10)))`
+
+Increment ladder:
+
+- `< 60s` → 5s step
+- `60–119s` → 10s step
+- `≥ 120s` → 15s step
+
+Targets are snapped to multiples of 5 seconds for readability and floored at 5s.
+
+## Service layer
+
+In the existing exercise-execution setup path in `internal/workout/service.go`:
+
+```go
+if exercise.IsTimed() {
+    starting := s.GetStartingSeconds(ctx, exerciseID, date)  // last completed_value, fallback to default_starting_seconds
+    progression := exerciseprogression.NewTimed(TimedConfig{StartingSeconds: starting})
+    // ...
+} else {
+    // existing weighted/assisted path via BuildProgression / GetStartingWeight
+}
+```
+
+`GetStartingSeconds` is a new service method analogous to `GetStartingWeight`
+(`service.go:557`): it pulls the latest successful set for this exercise — the
+last set in DESC order by `(workout_date, set_number)` from sessions strictly
+before the current date, where `completed_value IS NOT NULL` and
+`signal IN ('on_target', 'too_light')` — and returns its `completed_value`.
+Falls back to `exercise.DefaultStartingSeconds` when no successful history
+exists. No periodization-based conversion is needed because periodization
+does not apply to time-based exercises.
+
+`UpdateCompletedReps` becomes `UpdateCompletedValue` — the handler passes a
+unit-agnostic integer.
+
+## Planner
+
+`internal/weekplanner/weekplanner.go` emits a single `target_value` per
+`PlannedSet` instead of `MinReps`/`MaxReps`:
+
+- Rep-based: `TargetReps(periodization)` (5 or 8).
+- Time-based: caller-supplied starting seconds (from service-layer history
+  derivation).
+
+`setsForPeriodization` collapses from returning `(minR, maxR int)` to
+returning a single integer. Display range derivation moves out of storage and
+into the render-time helper.
+
+## UI
+
+`cmd/web/handler-exerciseset.go`:
+
+- `formatRepRange(min, max int) string` becomes
+  `formatTarget(exercise Exercise, session Session, target int) string`:
+  - `time_based` → `"30s"`
+  - rep-based + strength → `"5"`
+  - rep-based + hypertrophy → `"6-10"`
+- `setDisplay` exposes pre-formatted `TargetStr`, `CompletedStr`, plus a
+  `Unit` string ("reps" or "seconds") for input labels.
+- Form field renames: `completed_reps` → `completed_value`. Same numeric input.
+
+Templates (`ui/templates/pages/exerciseset/sets-container.gohtml`,
+`pages/workout/workout.gohtml`) read `setDisplay`'s pre-formatted strings —
+no per-template unit branching.
+
+`cmd/web/handler-exercise-info.go`'s `processEntryData` already switches on
+`ExerciseType` to format chart entries (e.g., `"8x100kg"` for weighted,
+`"8 reps"` for bodyweight). Add a `case ExerciseTypeTime` branch that
+formats `"30s"` from `set.CompletedValue`.
+
+Admin form (`cmd/web/handler-admin-exercises.go`) adds `time_based` to the
+type dropdown and a `default_starting_seconds` field shown only for that type.
+
+## Out of scope
+
+- Weighted timed holds (weighted dead hang, weighted plank). `time_based`
+  implies no `weight_kg`.
+- MM:SS input format. Plain integer seconds.
+- Time-based ranges (hold 30–45s). Single target.
+- Catalog expansion (dead hang, L-sit, wall sit, farmer's carry). The schema
+  supports them without further changes; populate as needed.
+- Cross-session conversion logic for time-based — `conversion.go` is
+  rep-domain.
+- The bigger attribute-driven prescription in
+  `specs/01-exercise-attributes.md`. This work doesn't depend on it;
+  per-exercise time targets eventually subsume into that system's
+  `default_*` overrides.
+
+## Acceptance
+
+- Admin form roundtrips a `time_based` exercise; plank fixture lands with
+  `default_starting_seconds = 30`.
+- First-time plank session renders "Target: 30s" with a numeric input;
+  submitting 35 with `Signal=too_light` causes the next set to render
+  "Target: 35s".
+- Cross-session: a plank session whose final set was 40s with
+  `Signal=on_target` opens the next plank session at 40s.
+- Existing rep-based exercises (bench, deadlift, …) render unchanged: "5"
+  for strength sessions, "6-10" for hypertrophy.
+- Premigration test: legacy `exercise_sets` schema with hypertrophy bench
+  (min=6, max=10, completed=8) and a plank row migrates to
+  `target_value=10, completed_value=8` for bench, plank row dropped.
+  Idempotent on second invocation. `migrateTo(schemaDefinition)` is a no-op
+  afterward.
+- `TimedProgression` table-driven test covers ≥10 (current, signal) → next
+  pairs across the three increment buckets, plus the 5s floor and the
+  5s-snap rounding.
+- After premigration runs in production, file/test/legacy-schema constant
+  deleted in a single follow-up commit.
+
+## Brainstorming starter prompt
+
+> I want to brainstorm `specs/05-time-based-exercises.md`. Walk me through
+> the schema collapse (single `target_value` instead of min/max) — does it
+> lose anything that the rep-range UX gives users today? Sanity-check the
+> `TimedProgression` increment ladder against a real plank session
+> (start 30s, two too-lights, one on-target, one too-heavy). Then identify
+> edge cases the premigration must handle: sessions in progress at deploy
+> time, exercises whose type was changed mid-history, and any constraint
+> interaction with `workout_exercise.warmup_completed_at`.

--- a/ui/templates/pages/admin-exercise-edit/admin-exercise-edit.gohtml
+++ b/ui/templates/pages/admin-exercise-edit/admin-exercise-edit.gohtml
@@ -30,8 +30,39 @@
                     <option value="assisted" {{ if eq .Exercise.ExerciseType "assisted" }}selected{{ end }}>
                         Assisted
                     </option>
+                    <option value="time_based" {{ if eq .Exercise.ExerciseType "time_based" }}selected{{ end }}>
+                        Time-based
+                    </option>
                 </select>
             </div>
+
+            <div id="default-starting-seconds-field"{{ if ne .Exercise.ExerciseType "time_based" }} hidden{{ end }}>
+                <label for="default_starting_seconds">Default Starting Seconds:</label>
+                <input type="number"
+                       id="default_starting_seconds"
+                       name="default_starting_seconds"
+                       min="1"
+                       value="{{ .DefaultStartingSecondsValue }}"
+                       {{ if eq .Exercise.ExerciseType "time_based" }}required{{ end }}>
+                <small>Number of seconds to hold on the first set for new users.</small>
+            </div>
+
+            <script {{ nonce }}>
+                (function () {
+                    const typeSelect = document.getElementById('exercise_type');
+                    const field = document.getElementById('default-starting-seconds-field');
+                    const input = document.getElementById('default_starting_seconds');
+
+                    function update() {
+                        const isTimed = typeSelect.value === 'time_based';
+                        field.hidden = !isTimed;
+                        input.required = isTimed;
+                    }
+
+                    typeSelect.addEventListener('change', update);
+                    update();
+                })();
+            </script>
 
             <div>
                 <label for="primary_muscles">Primary Muscle Groups:</label>

--- a/ui/templates/pages/exerciseset/sets-container.gohtml
+++ b/ui/templates/pages/exerciseset/sets-container.gohtml
@@ -303,17 +303,17 @@
 
         {{ range $index, $setDisplay := .SetsDisplay }}
             {{ $set := $setDisplay.Set }}
-            {{ $isActive := and $.ExerciseSet.WarmupCompletedAt (or (and (not $set.CompletedReps) (eq $.FirstIncompleteIndex $index)) (and $.IsEditing (eq $index $.EditingIndex))) }}
-            <div class="exercise-set{{ if $set.CompletedReps }} completed{{ end }}{{ if $isActive }} active{{ end }}"
+            {{ $isActive := and $.ExerciseSet.WarmupCompletedAt (or (and (not $set.CompletedValue) (eq $.FirstIncompleteIndex $index)) (and $.IsEditing (eq $index $.EditingIndex))) }}
+            <div class="exercise-set{{ if $set.CompletedValue }} completed{{ end }}{{ if $isActive }} active{{ end }}"
                  role="group"
                  {{ if $isActive }}aria-current="step"{{ end }}
-                 aria-label="{{ if $set.CompletedReps }}Completed set{{ else if $isActive }}Current set{{ else }}Upcoming set{{ end }}">
+                 aria-label="{{ if $set.CompletedValue }}Completed set{{ else if $isActive }}Current set{{ else }}Upcoming set{{ end }}">
                 <div class="set-info">
                     {{ if or (eq $.ExerciseSet.Exercise.ExerciseType "weighted") (eq $.ExerciseSet.Exercise.ExerciseType "assisted") }}
-                        {{ if $set.CompletedReps }}
+                        {{ if $set.CompletedValue }}
                             <span class="status-icon" aria-hidden="true">✓</span>
                             <span class="weight" aria-label="Weight">{{ formatFloat $set.WeightKg }} kg</span>
-                            <span class="reps" aria-label="Completed reps">{{ $set.CompletedReps }} reps</span>
+                            <span class="reps" aria-label="Completed reps">{{ $setDisplay.CompletedStr }} {{ $setDisplay.Unit }}</span>
                             {{ if $set.Signal }}
                                 <span class="signal-badge" aria-label="Signal">{{ $set.Signal }}</span>
                             {{ end }}
@@ -326,12 +326,12 @@
                             <span class="reps" aria-label="Target reps">{{ $.CurrentSetTarget.TargetReps }} reps</span>
                         {{ end }}
                     {{ else }}
-                        {{ if $set.CompletedReps }}
+                        {{ if $set.CompletedValue }}
                             <span class="status-icon" aria-hidden="true">✓</span>
-                            <span class="reps" aria-label="Completed reps">{{ $set.CompletedReps }} reps</span>
+                            <span class="reps" aria-label="Completed value">{{ $setDisplay.CompletedStr }} {{ $setDisplay.Unit }}</span>
                             <a href="?edit={{ $index }}" class="edit-button" aria-label="Edit set {{ $setDisplay.Number }}">Edit</a>
                         {{ else }}
-                            <span class="reps" aria-label="Target reps">{{ $setDisplay.RepStr }} reps</span>
+                            <span class="reps" aria-label="Target value">{{ $setDisplay.TargetStr }} {{ $setDisplay.Unit }}</span>
                         {{ end }}
                     {{ end }}
                 </div>
@@ -407,16 +407,16 @@
                               class="set-form bodyweight-form"
                               aria-label="Complete current set">
                             <div class="input-field">
-                                <label for="reps-{{ $index }}">Reps</label>
+                                <label for="completed-value-{{ $index }}">{{ $setDisplay.Unit }}</label>
                                 <input
-                                        id="reps-{{ $index }}"
+                                        id="completed-value-{{ $index }}"
                                         inputmode="numeric"
                                         pattern="[0-9]*"
-                                        name="reps"
-                                        placeholder="{{ $setDisplay.RepStr }}"
-                                        {{ if $set.CompletedReps }}value="{{ $set.CompletedReps }}"{{ end }}
+                                        name="completed_value"
+                                        placeholder="{{ $setDisplay.TargetStr }}"
+                                        {{ if $set.CompletedValue }}value="{{ $setDisplay.CompletedStr }}"{{ end }}
                                         required
-                                        {{ if $set.CompletedReps }}disabled{{ end }}
+                                        {{ if $set.CompletedValue }}disabled{{ end }}
                                         class="reps-input"
                                 >
                             </div>

--- a/ui/templates/pages/exerciseset/sets-container.gohtml
+++ b/ui/templates/pages/exerciseset/sets-container.gohtml
@@ -330,6 +330,8 @@
                             <span class="status-icon" aria-hidden="true">✓</span>
                             <span class="reps" aria-label="Completed value">{{ $setDisplay.CompletedStr }} {{ $setDisplay.Unit }}</span>
                             <a href="?edit={{ $index }}" class="edit-button" aria-label="Edit set {{ $setDisplay.Number }}">Edit</a>
+                        {{ else if and (eq $.ExerciseSet.Exercise.ExerciseType "time_based") $.ExerciseSet.WarmupCompletedAt (eq $.FirstIncompleteIndex $index) }}
+                            <span class="reps" aria-label="Recommended target">{{ $.CurrentSetTimedTarget }}s</span>
                         {{ else }}
                             <span class="reps" aria-label="Target value">{{ $setDisplay.TargetStr }} {{ $setDisplay.Unit }}</span>
                         {{ end }}
@@ -397,6 +399,39 @@
                                     <button type="submit" name="signal" value="too_light"
                                             class="signal-btn too-light-btn"
                                             aria-label="Could have done more reps">Could do more</button>
+                                </div>
+                            </fieldset>
+                        </form>
+                    {{ else if eq $.ExerciseSet.Exercise.ExerciseType "time_based" }}
+                        <form method="post"
+                              action="/workouts/{{ $.Date.Format "2006-01-02" }}/exercises/{{ $.ExerciseSet.ID }}/sets/{{ $index }}/update"
+                              id="form-{{ $index }}"
+                              class="set-form timed-form"
+                              aria-label="Complete current hold">
+                            <div class="input-field">
+                                <label for="completed-value-{{ $index }}">Seconds held</label>
+                                <input
+                                        id="completed-value-{{ $index }}"
+                                        inputmode="numeric"
+                                        pattern="[0-9]*"
+                                        name="completed_value"
+                                        value="{{ $.CurrentSetTimedTarget }}"
+                                        required
+                                        class="reps-input"
+                                >
+                            </div>
+                            <fieldset class="signal-group">
+                                <legend>Did you reach {{ $.CurrentSetTimedTarget }}s?</legend>
+                                <div class="signal-buttons">
+                                    <button type="submit" name="signal" value="too_heavy"
+                                            class="signal-btn too-heavy-btn"
+                                            aria-label="No, I failed to reach the target hold">No</button>
+                                    <button type="submit" name="signal" value="on_target"
+                                            class="signal-btn on-target-btn"
+                                            aria-label="Barely reached target hold">Barely</button>
+                                    <button type="submit" name="signal" value="too_light"
+                                            class="signal-btn too-light-btn"
+                                            aria-label="Could have held longer">Could do more</button>
                                 </div>
                             </fieldset>
                         </form>

--- a/ui/templates/pages/workout/workout.gohtml
+++ b/ui/templates/pages/workout/workout.gohtml
@@ -184,7 +184,7 @@
                 {{ $allSetsCompleted := true }}
                 {{ $hasSomeCompleted := false }}
                 {{ range .Sets }}
-                    {{ if eq .CompletedReps nil }}
+                    {{ if eq .CompletedValue nil }}
                         {{ $allSetsCompleted = false }}
                     {{ else }}
                         {{ $hasSomeCompleted = true }}


### PR DESCRIPTION
## Summary

- Introduces a fourth `exercise_type` value `time_based` so plank prescribes a duration (e.g., "Hold 30s") instead of meaningless rep counts. Auto-regulation works the same as weighted exercises — Signal feedback bumps target seconds up/down.
- Collapses `exercise_sets.min_reps`/`max_reps`/`completed_reps` into single `target_value`/`completed_value`. The rep range was display-only (the planner already stored a single integer); collapsing removes redundant data and gives time-based exercises a place to land.
- Includes a one-shot premigration that translates legacy rows: `target_value := max_reps`, `completed_value := completed_reps`, drops historical Plank rows whose stored reps would be nonsense to reinterpret as seconds.

## Spec & plan

- Design: `specs/05-time-based-exercises.md`
- Implementation plan: `docs/superpowers/plans/2026-05-07-time-based-exercises.md`

## Architecture

- New parallel engine `TimedProgression` in `internal/exerciseprogression/` mirrors weighted `Progression` with a 5/10/15s ladder under/at/over 60s/120s, 5s floor, snap to multiples of 5.
- New service methods: `GetStartingSeconds`, `BuildTimedProgression`, `RecordTimedSetCompletion`. Each mirrors its weighted counterpart.
- Schema CHECK enforces invariant: `time_based` exercises must have non-NULL `default_starting_seconds`.
- Plank fixture flips via an atomic UPDATE after the main INSERT (sidesteps the CHECK during seeding).
- Admin form: fourth dropdown option + conditional `default_starting_seconds` input toggled via inline JS (CSP-compliant via `{{ nonce }}`).

## Post-deploy cleanup

After this ships to production, delete `internal/sqlite/premigrate.go`, the call site in `NewDatabase`, the `legacyExerciseSetsSchema` constant, and the test in `migrate_internal_test.go` in a single follow-up commit. Same lifecycle as PR #75.

## Known follow-ups (non-blocking)

- `BuildProgression`/`BuildTimedProgression` Signal switches lack a `default` case (pre-existing pattern; unreachable due to DB CHECK on signal).
- No direct unit test for `RecordTimedSetCompletion` (transitive coverage via `BuildTimedProgression` tests).
- No e2e test for the admin `time_based` form path.

## Test plan

- [ ] Boot a fresh dev DB; verify plank renders "Target: 30s" with a numeric input on first session.
- [ ] Submit set 1 with 35s + `too_light` → next set shows "Target: 40s".
- [ ] Complete a session ending at 40s `on_target`; verify next plank session opens at 40s.
- [ ] Verify rep-based exercises (bench, deadlift) render unchanged: "5" for strength, "6-10" for hypertrophy.
- [ ] Visit the plank exercise-info page; verify history rows show "Xs" instead of "X reps".
- [ ] Run premigration test: `go test ./internal/sqlite/ -run TestPreMigrateExerciseSetTarget -v`.
- [ ] Run full suite: `make ci`.
- [ ] Admin form: create a new `time_based` exercise; switch type to `weighted` and verify the seconds field hides; submit valid + invalid `default_starting_seconds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
