### PR TITLE
fix(workout): seed time_based defaults when adding/swapping plank

### DIFF
--- a/internal/workout/service.go
+++ b/internal/workout/service.go
@@ -942,7 +942,8 @@ func (s *Service) SwapExercise(
 	workoutExerciseID int,
 	newExerciseID int,
 ) error {
-	if _, err := s.repo.exercises.Get(ctx, newExerciseID); err != nil {
+	newExercise, err := s.repo.exercises.Get(ctx, newExerciseID)
+	if err != nil {
 		return fmt.Errorf("get new exercise: %w", err)
 	}
 
@@ -951,7 +952,7 @@ func (s *Service) SwapExercise(
 		return fmt.Errorf("find historical sets: %w", err)
 	}
 
-	if err = s.replaceExerciseInSession(ctx, date, workoutExerciseID, newExerciseID, historicalSets); err != nil {
+	if err = s.replaceExerciseInSession(ctx, date, workoutExerciseID, newExercise, historicalSets); err != nil {
 		return err
 	}
 
@@ -959,6 +960,9 @@ func (s *Service) SwapExercise(
 }
 
 // findHistoricalSets retrieves set data from the most recent usage of an exercise.
+// Aggregates with no sets are skipped — they exist for exercises whose historical
+// exercise_sets rows were dropped by the time-based premigration but whose
+// workout_exercise slot survived. Returns nil when no usable history is found.
 func (s *Service) findHistoricalSets(ctx context.Context, date time.Time, exerciseID int) ([]Set, error) {
 	// Get workout history (past 3 months)
 	threeMonthsAgo := date.AddDate(0, -3, 0)
@@ -976,10 +980,11 @@ func (s *Service) findHistoricalSets(ctx context.Context, date time.Time, exerci
 		}
 
 		for _, exerciseSet := range session.ExerciseSets {
-			if exerciseSet.ExerciseID == exerciseID {
-				// Copy sets and reset completion status
-				return s.copySetsWithoutCompletion(exerciseSet.Sets), nil
+			if exerciseSet.ExerciseID != exerciseID || len(exerciseSet.Sets) == 0 {
+				continue
 			}
+			// Copy sets and reset completion status
+			return s.copySetsWithoutCompletion(exerciseSet.Sets), nil
 		}
 	}
 
@@ -1002,17 +1007,21 @@ func (s *Service) copySetsWithoutCompletion(sets []Set) []Set {
 	return result
 }
 
-// createEmptySets creates new sets with zero weight based on the structure of template sets.
-func (s *Service) createEmptySets(templateSets []Set) []Set {
-	result := make([]Set, len(templateSets))
-	for i, set := range templateSets {
+// createDefaultSets returns n empty sets seeded with type-appropriate defaults
+// for the target exercise: DefaultStartingSeconds (TargetValue) and nil weight
+// for time_based, defaultTargetValue and nil weight for bodyweight, and
+// defaultTargetValue with a zero-weight pointer for weighted/assisted.
+func (s *Service) createDefaultSets(ex Exercise, n int) []Set {
+	target := defaultTargetValueFor(ex)
+	result := make([]Set, n)
+	for i := range result {
 		var weight *float64
-		if set.WeightKg != nil {
-			weight = new(float64) // Empty weight for weighted exercises.
+		if !ex.IsTimed() && ex.ExerciseType != ExerciseTypeBodyweight {
+			weight = new(float64)
 		}
 		result[i] = Set{
 			WeightKg:       weight,
-			TargetValue:    set.TargetValue,
+			TargetValue:    target,
 			CompletedValue: nil,
 			CompletedAt:    nil,
 			Signal:         nil,
@@ -1021,15 +1030,24 @@ func (s *Service) createEmptySets(templateSets []Set) []Set {
 	return result
 }
 
+// defaultTargetValueFor returns the default TargetValue for a fresh set on this
+// exercise — DefaultStartingSeconds for time_based, defaultTargetValue otherwise.
+func defaultTargetValueFor(ex Exercise) int {
+	if ex.IsTimed() && ex.DefaultStartingSeconds != nil {
+		return *ex.DefaultStartingSeconds
+	}
+	return defaultTargetValue
+}
+
 // replaceExerciseInSession swaps the exercise occupying a workout slot, keeping
 // the slot's stable ID intact. Any previously recorded sets on the slot are
 // dropped — historicalSets seeds the replacement when present, otherwise we
-// generate empty placeholders matching the old set count.
+// generate type-appropriate placeholders matching the old set count.
 func (s *Service) replaceExerciseInSession(
 	ctx context.Context,
 	date time.Time,
 	workoutExerciseID int,
-	newExerciseID int,
+	newExercise Exercise,
 	historicalSets []Set,
 ) error {
 	err := s.repo.sessions.Update(ctx, date, func(sess *sessionAggregate) (bool, error) {
@@ -1037,12 +1055,12 @@ func (s *Service) replaceExerciseInSession(
 			if exerciseSet.ID != workoutExerciseID {
 				continue
 			}
-			sess.ExerciseSets[i].ExerciseID = newExerciseID
+			sess.ExerciseSets[i].ExerciseID = newExercise.ID
 			sess.ExerciseSets[i].WarmupCompletedAt = nil
 			if historicalSets != nil {
 				sess.ExerciseSets[i].Sets = historicalSets
 			} else {
-				sess.ExerciseSets[i].Sets = s.createEmptySets(exerciseSet.Sets)
+				sess.ExerciseSets[i].Sets = s.createDefaultSets(newExercise, len(exerciseSet.Sets))
 			}
 			return true, nil
 		}
@@ -1118,18 +1136,9 @@ func (s *Service) AddExercise(ctx context.Context, date time.Time, exerciseID in
 			// Use historical sets if available
 			newSets = historicalSets
 		} else {
-			// Create default sets if no historical data exists
+			// Create type-appropriate default sets if no historical data exists
 			const defaultSetCount = 3
-			newSets = make([]Set, defaultSetCount)
-			for i := range newSets {
-				newSets[i] = Set{
-					WeightKg:       new(float64),
-					TargetValue:    defaultTargetValue,
-					CompletedValue: nil,
-					CompletedAt:    nil,
-					Signal:         nil,
-				}
-			}
+			newSets = s.createDefaultSets(exercise, defaultSetCount)
 		}
 
 		// Add the new exercise to the session. ID stays 0 so the repository

--- a/internal/workout/service_test.go
+++ b/internal/workout/service_test.go
@@ -774,6 +774,222 @@ func Test_AddExercise_UsesMostRecentHistoricalWeight(t *testing.T) {
 	}
 }
 
+// Test_AddExercise_TimeBased_NoHistory_SeedsDefaultStartingSeconds verifies
+// that adding a time-based exercise with no usable history produces three
+// sets pre-seeded with the exercise's DefaultStartingSeconds rather than
+// the rep-based defaultTargetValue or zero sets.
+//
+// Regression: the time_based premigration in PR #87 dropped historical
+// exercise_sets rows for plank but kept the workout_exercise slots. The
+// resulting empty (but non-nil) history slice slipped past the
+// `historicalSets != nil` check and persisted zero sets, so the user saw
+// a blank exercise page when adding or swapping to plank.
+func Test_AddExercise_TimeBased_NoHistory_SeedsDefaultStartingSeconds(t *testing.T) {
+	ctx := t.Context()
+	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))
+	db, err := sqlite.NewDatabase(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("create test database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var userID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		"INSERT INTO users (webauthn_user_id, display_name) VALUES (?, ?) RETURNING id",
+		[]byte("plank-user"), "Plank User").Scan(&userID)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
+	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
+
+	svc := workout.NewService(db, logger, "")
+
+	if err = tryInsertMuscleGroup(ctx, t, db, "Core"); err != nil {
+		t.Fatalf("insert muscle group: %v", err)
+	}
+
+	const startingSeconds = 30
+	var plankID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		`INSERT INTO exercises (name, category, exercise_type, default_starting_seconds, description_markdown)
+		 VALUES (?, 'full_body', 'time_based', ?, '') RETURNING id`,
+		"TestPlankAdd", startingSeconds).Scan(&plankID)
+	if err != nil {
+		t.Fatalf("insert plank exercise: %v", err)
+	}
+
+	today := time.Now()
+	dateStr := today.Format("2006-01-02")
+
+	// Simulate the post-premigration state: a historical workout_exercise slot
+	// for plank exists but its exercise_sets rows were dropped.
+	historicalDate := today.AddDate(0, 0, -7).Format("2006-01-02")
+	if _, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO workout_sessions (user_id, workout_date) VALUES (?, ?)",
+		userID, historicalDate); err != nil {
+		t.Fatalf("insert historical session: %v", err)
+	}
+	if _, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id) VALUES (?, ?, ?)`,
+		userID, historicalDate, plankID); err != nil {
+		t.Fatalf("insert orphaned workout_exercise: %v", err)
+	}
+
+	// Today's empty session.
+	if _, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO workout_sessions (user_id, workout_date) VALUES (?, ?)",
+		userID, dateStr); err != nil {
+		t.Fatalf("insert today's session: %v", err)
+	}
+
+	if _, err = svc.AddExercise(ctx, today, plankID); err != nil {
+		t.Fatalf("AddExercise: %v", err)
+	}
+
+	session, err := svc.GetSession(ctx, today)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+
+	var plankSets []workout.Set
+	for _, es := range session.ExerciseSets {
+		if es.Exercise.ID == plankID {
+			plankSets = es.Sets
+			break
+		}
+	}
+	if len(plankSets) != 3 {
+		t.Fatalf("expected 3 plank sets seeded, got %d", len(plankSets))
+	}
+	for i, set := range plankSets {
+		if set.TargetValue != startingSeconds {
+			t.Errorf("set %d TargetValue: want %d, got %d", i, startingSeconds, set.TargetValue)
+		}
+		if set.WeightKg != nil {
+			t.Errorf("set %d WeightKg: want nil for time_based, got %v", i, *set.WeightKg)
+		}
+	}
+}
+
+// Test_SwapExercise_ToTimeBased_NoHistory_SeedsDefaultStartingSeconds verifies
+// that swapping into a time-based exercise (e.g. plank) without usable
+// history produces sets pre-seeded with DefaultStartingSeconds, not the
+// previous exercise's rep target. Regression for the same orphaned-history
+// case as Test_AddExercise_TimeBased_NoHistory_SeedsDefaultStartingSeconds.
+func Test_SwapExercise_ToTimeBased_NoHistory_SeedsDefaultStartingSeconds(t *testing.T) {
+	ctx := t.Context()
+	logger := testhelpers.NewLogger(testhelpers.NewWriter(t))
+	db, err := sqlite.NewDatabase(ctx, ":memory:", logger)
+	if err != nil {
+		t.Fatalf("create test database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var userID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		"INSERT INTO users (webauthn_user_id, display_name) VALUES (?, ?) RETURNING id",
+		[]byte("swap-user"), "Swap User").Scan(&userID)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	ctx = context.WithValue(ctx, contexthelpers.AuthenticatedUserIDContextKey, userID)
+	ctx = context.WithValue(ctx, contexthelpers.IsAuthenticatedContextKey, true)
+
+	svc := workout.NewService(db, logger, "")
+
+	for _, group := range []string{"Core", "Quads"} {
+		if err = tryInsertMuscleGroup(ctx, t, db, group); err != nil {
+			t.Fatalf("insert muscle group: %v", err)
+		}
+	}
+
+	squatID, err := createTestExercise(ctx, t, db, "Squat", "lower")
+	if err != nil {
+		t.Fatalf("create squat: %v", err)
+	}
+
+	const startingSeconds = 30
+	var plankID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		`INSERT INTO exercises (name, category, exercise_type, default_starting_seconds, description_markdown)
+		 VALUES (?, 'full_body', 'time_based', ?, '') RETURNING id`,
+		"TestPlankSwap", startingSeconds).Scan(&plankID)
+	if err != nil {
+		t.Fatalf("insert plank: %v", err)
+	}
+
+	today := time.Now()
+	dateStr := today.Format("2006-01-02")
+
+	// Simulate orphaned historical plank row from the premigration.
+	historicalDate := today.AddDate(0, 0, -7).Format("2006-01-02")
+	if _, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO workout_sessions (user_id, workout_date) VALUES (?, ?)",
+		userID, historicalDate); err != nil {
+		t.Fatalf("insert historical session: %v", err)
+	}
+	if _, err = db.ReadWrite.ExecContext(ctx,
+		`INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id) VALUES (?, ?, ?)`,
+		userID, historicalDate, plankID); err != nil {
+		t.Fatalf("insert orphaned workout_exercise: %v", err)
+	}
+
+	// Today's session with squat occupying a slot.
+	if _, err = db.ReadWrite.ExecContext(ctx,
+		"INSERT INTO workout_sessions (user_id, workout_date) VALUES (?, ?)",
+		userID, dateStr); err != nil {
+		t.Fatalf("insert today's session: %v", err)
+	}
+	var squatSlotID int
+	err = db.ReadWrite.QueryRowContext(ctx,
+		`INSERT INTO workout_exercise (workout_user_id, workout_date, exercise_id)
+		 VALUES (?, ?, ?) RETURNING id`,
+		userID, dateStr, squatID).Scan(&squatSlotID)
+	if err != nil {
+		t.Fatalf("insert squat slot: %v", err)
+	}
+	for i := 1; i <= 3; i++ {
+		if _, err = db.ReadWrite.ExecContext(ctx,
+			`INSERT INTO exercise_sets (workout_exercise_id, set_number, weight_kg, target_value)
+			 VALUES (?, ?, ?, ?)`,
+			squatSlotID, i, 60.0, 5); err != nil {
+			t.Fatalf("insert squat set: %v", err)
+		}
+	}
+
+	if err = svc.SwapExercise(ctx, today, squatSlotID, plankID); err != nil {
+		t.Fatalf("SwapExercise: %v", err)
+	}
+
+	session, err := svc.GetSession(ctx, today)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+
+	var plankSets []workout.Set
+	for _, es := range session.ExerciseSets {
+		if es.ID == squatSlotID {
+			if es.Exercise.ID != plankID {
+				t.Fatalf("slot %d still maps to exercise %d, want %d", es.ID, es.Exercise.ID, plankID)
+			}
+			plankSets = es.Sets
+			break
+		}
+	}
+	if len(plankSets) != 3 {
+		t.Fatalf("expected 3 plank sets, got %d", len(plankSets))
+	}
+	for i, set := range plankSets {
+		if set.TargetValue != startingSeconds {
+			t.Errorf("set %d TargetValue: want %d, got %d", i, startingSeconds, set.TargetValue)
+		}
+		if set.WeightKg != nil {
+			t.Errorf("set %d WeightKg: want nil for time_based, got %v", i, *set.WeightKg)
+		}
+	}
+}
+
 // Helper function to create a test exercise.
 func createTestExercise(ctx context.Context, t *testing.T, db *sqlite.Database, name, category string) (int, error) {
 	t.Helper()


### PR DESCRIPTION
The premigration in PR #87 dropped historical exercise_sets rows for
plank but kept the workout_exercise slots. findHistoricalSets returned
the resulting empty (but non-nil) slice, so the historicalSets != nil
check in AddExercise/SwapExercise treated it as valid history and
persisted zero sets — leaving the user staring at the warmup banner
with nothing below it.

Skip aggregates with no sets in findHistoricalSets, and route
SwapExercise/AddExercise's no-history path through a single
createDefaultSets helper that honours exercise type: time_based gets
DefaultStartingSeconds with nil weight, bodyweight gets nil weight,
and weighted/assisted keep the zero-weight pointer.