### PR TITLE
Swap the button loading text for an in-place spinner

### DIFF
--- a/ui/static/main.css
+++ b/ui/static/main.css
@@ -279,6 +279,32 @@
         &:focus-visible {
             outline: var(--clay-3) solid 2px;
         }
+
+        /*
+         * Loading state. The label stays in the DOM (just visually hidden via
+         * transparent text) so the button keeps its exact width and height —
+         * swapping the textContent would reflow the button and cause a flicker.
+         * The live region in base.gohtml carries the "Loading…" announcement
+         * for screen readers; aria-busy here signals the busy state on the
+         * control itself.
+         */
+        &[aria-busy="true"] {
+            color: transparent;
+            cursor: wait;
+        }
+
+        &[aria-busy="true"]::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            margin: auto;
+            width: 1em;
+            height: 1em;
+            border: 2px solid color-mix(in oklab, var(--color-surface-elevated) 35%, transparent);
+            border-top-color: var(--color-surface-elevated);
+            border-radius: 50%;
+            animation: button-spinner 0.8s linear infinite;
+        }
     }
 
 
@@ -453,6 +479,10 @@ html:active-view-transition-type(backward) {
     to { background-position: 167% 0; }
 }
 
+@keyframes button-spinner {
+    to { transform: rotate(1turn); }
+}
+
 @media (prefers-reduced-motion: reduce) {
     #loading-bar {
         transition: none;
@@ -461,11 +491,21 @@ html:active-view-transition-type(backward) {
         animation: none;
         background: var(--clay-3);
     }
+    button[aria-busy="true"]::after,
+    .btn[aria-busy="true"]::after {
+        animation: none;
+    }
 }
 
 @media (forced-colors: active) {
     #loading-bar.active {
         background: Highlight;
+        forced-color-adjust: none;
+    }
+    button[aria-busy="true"]::after,
+    .btn[aria-busy="true"]::after {
+        border-color: CanvasText;
+        border-top-color: Highlight;
         forced-color-adjust: none;
     }
 }

--- a/ui/static/main.js
+++ b/ui/static/main.js
@@ -74,8 +74,8 @@ const sameUrl = (a, b) =>
 /**
  * Navigation feedback state.
  *
- * `activeLoad` records the in-flight visual feedback so we can restore the
- * source element's text and hide the bar when:
+ * `activeLoad` records the in-flight visual feedback so we can clear the
+ * source element's busy state and hide the bar when:
  *   - bfcache restores a page that was mid-navigation (pageshow.persisted)
  *   - the user cancels a navigation (navigateerror)
  *   - a new navigation supersedes the current one
@@ -92,26 +92,27 @@ let activeLoad = null
 function startLoad(el) {
     clearLoad()
 
-    // Only buttons swap text — anchor labels are part of page content and
-    // changing them right before the browser tears down the document for a
-    // GET navigation is noisy without being reliably visible.
+    // Only buttons show the inline spinner — anchor labels are part of page
+    // content and overlaying a spinner right before the browser tears down
+    // the document for a GET navigation is noisy without being reliably
+    // visible. The button keeps its label in the DOM; CSS hides the text
+    // (preserving the button's width and height) and paints the spinner via
+    // ::after, which is why we do not swap textContent.
     const target = (el instanceof HTMLButtonElement && el.textContent?.trim()) ? el : null
-    let originalText = null
     if (target) {
-        originalText = target.textContent
-        target.textContent = 'Loading…'
+        target.setAttribute('aria-busy', 'true')
     }
 
     document.getElementById('loading-bar').classList.add('active')
     document.getElementById('loading-announce').textContent = 'Loading…'
 
-    activeLoad = { target, originalText }
+    activeLoad = { target }
 }
 
 function clearLoad() {
     if (!activeLoad) return
     if (activeLoad.target && activeLoad.target.isConnected) {
-        activeLoad.target.textContent = activeLoad.originalText
+        activeLoad.target.removeAttribute('aria-busy')
     }
     document.getElementById('loading-bar').classList.remove('active')
     document.getElementById('loading-announce').textContent = ''

--- a/ui/templates/pages/styleguide/styleguide.gohtml
+++ b/ui/templates/pages/styleguide/styleguide.gohtml
@@ -400,6 +400,7 @@
             <div class="component-sample">
                 <button type="button">Default</button>
                 <a class="btn" href="#">Anchor as button</a>
+                <button type="button" aria-busy="true">Loading</button>
             </div>
 
             <h3>Back link</h3>


### PR DESCRIPTION
Replacing the button label with "Loading…" reflowed the button to the
new text width, which produced a visible flicker on every submit. Set
aria-busy on the source button instead and let CSS hide the label
(transparent text preserves the box) and paint a centered spinner via
::after. The live region in base.gohtml still carries the polite
"Loading…" announcement, so screen-reader feedback is unchanged.

Reduced-motion freezes the ring; forced-colors swaps to system colors.