### PR TITLE
Let PR review-app previews boot with ephemeral VAPID keys

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -199,14 +200,16 @@ const (
 	sessionLifetime = 7 * 24 * time.Hour
 )
 
-// ensureVAPIDKeys validates the VAPID config: production requires both keys
-// to be set via Fly secrets; dev generates an ephemeral pair on each start
-// and logs the public key.
+// ensureVAPIDKeys validates the VAPID config: petra and petra-staging require
+// both keys to be set via Fly secrets; dev and pr-* review apps generate an
+// ephemeral pair on each start and log the public key. Review-app push delivery
+// won't actually reach real browsers (the public key rotates per boot), but the
+// app boots and the UI renders.
 func ensureVAPIDKeys(ctx context.Context, cfg *config, logger *slog.Logger) error {
 	if cfg.VAPIDPublic != "" && cfg.VAPIDPrivate != "" {
 		return nil
 	}
-	if cfg.FlyAppName != "" {
+	if cfg.FlyAppName != "" && !strings.HasPrefix(cfg.FlyAppName, "pr-") {
 		return errors.New("PETRAPP_VAPID_PUBLIC and PETRAPP_VAPID_PRIVATE must be set in production")
 	}
 	priv, pub, err := webpush.GenerateVAPIDKeys()
@@ -214,7 +217,7 @@ func ensureVAPIDKeys(ctx context.Context, cfg *config, logger *slog.Logger) erro
 		return fmt.Errorf("generate dev vapid keys: %w", err)
 	}
 	cfg.VAPIDPrivate, cfg.VAPIDPublic = priv, pub
-	logger.LogAttrs(ctx, slog.LevelWarn, "generated ephemeral VAPID keys for dev",
+	logger.LogAttrs(ctx, slog.LevelWarn, "generated ephemeral VAPID keys",
 		slog.String("public", pub))
 	return nil
 }


### PR DESCRIPTION
## Summary

- Commit 9299e02 made `PETRAPP_VAPID_PUBLIC` / `PETRAPP_VAPID_PRIVATE` required on any Fly deploy. The review-app workflow doesn't inject those secrets, so every new preview crash-loops at boot and returns 502 (current state: PR #92's preview is unreachable; the smoke-test check fails accordingly).
- Detect `pr-*` Fly app names in `ensureVAPIDKeys` and fall through to the dev path that generates an ephemeral keypair. Staging and prod still require real secrets.
- Real push delivery to browsers still won't work in previews because the public key rotates per cold start — acceptable trade for being able to smoke-test PRs.

## Test plan

- [x] `make ci` clean on this branch (build + lint + tests + vuln scan)
- [ ] After merge: PR #92 preview redeploys and boots (no more `failure starting application` in `fly logs`)
- [ ] `https://pr-92-myrjola-petrapp.fly.dev/` returns 200 once the review-app workflow re-runs
- [ ] Future PR previews boot without manual secret injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)