### PR TITLE
Hide button label via .btn-loading-label span while busy

### DIFF
--- a/ui/static/main.css
+++ b/ui/static/main.css
@@ -281,16 +281,25 @@
         }
 
         /*
-         * Loading state. The label stays in the DOM (just visually hidden via
-         * transparent text) so the button keeps its exact width and height —
-         * swapping the textContent would reflow the button and cause a flicker.
-         * The live region in base.gohtml carries the "Loading…" announcement
-         * for screen readers; aria-busy here signals the busy state on the
+         * Loading state. JS wraps the button's children in a
+         * .btn-loading-label span and we hide that span with
+         * visibility:hidden — the span still participates in layout, so the
+         * button keeps its exact width and height while the ::after spinner
+         * replaces the visible label cleanly (no transparent-text artefacts
+         * like selection highlight or stray antialiasing). The fallback
+         * color:transparent on the button itself covers static-HTML aria-busy
+         * examples (e.g. the styleguide) that aren't wrapped by JS. The live
+         * region in base.gohtml carries the "Loading…" announcement for
+         * screen readers; aria-busy here signals the busy state on the
          * control itself.
          */
         &[aria-busy="true"] {
             color: transparent;
             cursor: wait;
+        }
+
+        &[aria-busy="true"] > .btn-loading-label {
+            visibility: hidden;
         }
 
         &[aria-busy="true"]::after {

--- a/ui/static/main.js
+++ b/ui/static/main.js
@@ -95,24 +95,36 @@ function startLoad(el) {
     // Only buttons show the inline spinner — anchor labels are part of page
     // content and overlaying a spinner right before the browser tears down
     // the document for a GET navigation is noisy without being reliably
-    // visible. The button keeps its label in the DOM; CSS hides the text
-    // (preserving the button's width and height) and paints the spinner via
-    // ::after, which is why we do not swap textContent.
+    // visible. We wrap the button's children in a .btn-loading-label span
+    // and hide it with visibility:hidden; the span still participates in
+    // layout, so the button keeps its exact width and height while the
+    // ::after spinner replaces the visible label. Stashing the original
+    // child nodes lets clearLoad — including the bfcache pageshow.persisted
+    // path — restore the button to its pre-click DOM.
     const target = (el instanceof HTMLButtonElement && el.textContent?.trim()) ? el : null
+    let originalChildren = null
     if (target) {
+        originalChildren = Array.from(target.childNodes)
+        const label = document.createElement('span')
+        label.className = 'btn-loading-label'
+        label.append(...originalChildren)
+        target.appendChild(label)
         target.setAttribute('aria-busy', 'true')
     }
 
     document.getElementById('loading-bar').classList.add('active')
     document.getElementById('loading-announce').textContent = 'Loading…'
 
-    activeLoad = { target }
+    activeLoad = { target, originalChildren }
 }
 
 function clearLoad() {
     if (!activeLoad) return
     if (activeLoad.target && activeLoad.target.isConnected) {
         activeLoad.target.removeAttribute('aria-busy')
+        if (activeLoad.originalChildren) {
+            activeLoad.target.replaceChildren(...activeLoad.originalChildren)
+        }
     }
     document.getElementById('loading-bar').classList.remove('active')
     document.getElementById('loading-announce').textContent = ''


### PR DESCRIPTION
## Summary

- Replace the transparent-text trick with a JS-wrapped `.btn-loading-label` span hidden via `visibility: hidden`. The span still participates in layout, so button width and height are unchanged, but the visible area is now fully owned by the `::after` spinner — no antialiasing fringe, selection highlight, or color blending against the spinner.
- `clearLoad` (which also runs on bfcache `pageshow.persisted`) restores the original child nodes, so the label — including any nested icons or spans — comes back intact when navigating back to a bfcached page.
- `color: transparent` stays as a fallback so static-HTML `aria-busy="true"` buttons (e.g. the styleguide demo) still hide their direct text content without needing the JS wrap.

## Test plan

- [x] `make lint-fix` clean, `go test --race ./cmd/web/...` passes including the full Playwright suite (`Test_playwright_*`) — those exercise `startLoad`/`clearLoad` through real button-click navigations.
- [ ] In the preview environment: click a submit button on a slow form and confirm (a) the label disappears cleanly and the spinner centers in the unchanged button box, (b) navigating back via the browser back button restores the original label text and any nested children.
- [ ] `/dev/styleguide` "Loading" button still renders correctly via the `color: transparent` fallback (no `.btn-loading-label` span on that static example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)