### PR TITLE
Target-aware weekly planner

### DIFF
--- a/internal/domain/muscle_group.go
+++ b/internal/domain/muscle_group.go
@@ -118,6 +118,29 @@ func WeeklyMuscleGroupVolume(
 	return result
 }
 
+// WeeklyPlannedLoad returns the running planned weighted load per
+// muscle group across the supplied sessions. Each set in the plan
+// contributes PrimarySetWeight to every primary muscle group on its
+// exercise and SecondarySetWeight to every secondary. Muscle groups
+// with zero contributions do not appear in the map. The result is the
+// running tally the target-aware planner uses to score subsequent
+// picks against the configured weekly targets.
+func WeeklyPlannedLoad(sessions []Session) map[string]float64 {
+	load := make(map[string]float64)
+	for _, sess := range sessions {
+		for _, ex := range sess.Slots {
+			n := float64(len(ex.Sets))
+			for _, mg := range ex.Exercise.PrimaryMuscleGroups {
+				load[mg] += n * PrimarySetWeight
+			}
+			for _, mg := range ex.Exercise.SecondaryMuscleGroups {
+				load[mg] += n * SecondarySetWeight
+			}
+		}
+	}
+	return load
+}
+
 // aggregateMuscleGroupLoad walks every set in the supplied sessions and totals the
 // weighted load for each muscle group, accumulating into the planned and completed
 // maps. Primary contributions count as PrimarySetWeight, secondary as

--- a/internal/domain/muscle_group_test.go
+++ b/internal/domain/muscle_group_test.go
@@ -52,3 +52,66 @@ func Test_WeeklyMuscleGroupVolume_PlannedAndCompleted(t *testing.T) {
 		t.Errorf("CompletedLoad = %v, want %v", got[0].CompletedLoad, domain.PrimarySetWeight)
 	}
 }
+
+func TestWeeklyPlannedLoad(t *testing.T) {
+	t.Parallel()
+
+	bench := domain.Exercise{ //nolint:exhaustruct // Test exercise omits display fields.
+		ID:                    1,
+		Name:                  "Bench Press",
+		Category:              domain.CategoryUpper,
+		ExerciseType:          domain.ExerciseTypeWeighted,
+		PrimaryMuscleGroups:   []string{"Chest", "Triceps"},
+		SecondaryMuscleGroups: []string{"Shoulders"},
+	}
+	pulldown := domain.Exercise{ //nolint:exhaustruct // Test exercise omits display fields.
+		ID:                    2,
+		Name:                  "Pulldown",
+		Category:              domain.CategoryUpper,
+		ExerciseType:          domain.ExerciseTypeWeighted,
+		PrimaryMuscleGroups:   []string{"Lats"},
+		SecondaryMuscleGroups: []string{"Biceps", "Shoulders"},
+	}
+
+	// One session with two exercises: bench 4 sets, pulldown 3 sets.
+	session := domain.Session{ //nolint:exhaustruct // Rest fields unused in this test.
+		Slots: []domain.ExerciseSlot{
+			{
+				Exercise: bench,
+				Sets:     make([]domain.Set, 4),
+			}, //nolint:exhaustruct // Sets carry no values in this test.
+			{
+				Exercise: pulldown,
+				Sets:     make([]domain.Set, 3),
+			}, //nolint:exhaustruct // Sets carry no values in this test.
+		},
+	}
+
+	got := domain.WeeklyPlannedLoad([]domain.Session{session})
+
+	want := map[string]float64{
+		"Chest":     4.0,       // 4 × 1.0 primary
+		"Triceps":   4.0,       // 4 × 1.0 primary
+		"Shoulders": 2.0 + 1.5, // bench secondary 4×0.5 + pulldown secondary 3×0.5
+		"Lats":      3.0,       // 3 × 1.0 primary
+		"Biceps":    1.5,       // 3 × 0.5 secondary
+	}
+	for mg, w := range want {
+		if got[mg] != w {
+			t.Errorf("load[%q] = %v, want %v", mg, got[mg], w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d MGs, want %d (extra entries: %v)", len(got), len(want), diffKeys(got, want))
+	}
+}
+
+func diffKeys(got map[string]float64, want map[string]float64) []string {
+	var extra []string
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			extra = append(extra, k)
+		}
+	}
+	return extra
+}

--- a/internal/domain/muscle_group_test.go
+++ b/internal/domain/muscle_group_test.go
@@ -76,14 +76,14 @@ func TestWeeklyPlannedLoad(t *testing.T) {
 	// One session with two exercises: bench 4 sets, pulldown 3 sets.
 	session := domain.Session{ //nolint:exhaustruct // Rest fields unused in this test.
 		Slots: []domain.ExerciseSlot{
-			{
+			{ //nolint:exhaustruct // WarmupCompletedAt unused in this test.
 				Exercise: bench,
 				Sets:     make([]domain.Set, 4),
-			}, //nolint:exhaustruct // Sets carry no values in this test.
-			{
+			},
+			{ //nolint:exhaustruct // WarmupCompletedAt unused in this test.
 				Exercise: pulldown,
 				Sets:     make([]domain.Set, 3),
-			}, //nolint:exhaustruct // Sets carry no values in this test.
+			},
 		},
 	}
 

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 )
 
@@ -109,23 +110,26 @@ func (wp *Planner) Plan(startingDate time.Time) (WeekPlan, error) {
 }
 
 // PlanDay generates one Session for date, suitable for ad-hoc workouts on
-// days outside the weekly plan (extra workouts, or days added mid-week after
-// Plan(monday) already ran). weekUsedExerciseIDs is the set of exercise IDs
-// already used in other sessions this week; the planner avoids repeating
-// them when possible. Returns errNoExercisesForCategory (wrapped) if the
-// derived category has no compatible exercises.
-func (wp *Planner) PlanDay(date time.Time, weekUsedExerciseIDs map[int]bool) (Session, error) {
+// days outside the weekly plan (extra workouts, or days added mid-week
+// after Plan(monday) already ran). weekUsedExerciseIDs is the set of
+// exercise IDs already used in other sessions this week; weekLoad is
+// the running per-MG weighted load from those sessions (built by the
+// caller via WeeklyPlannedLoad). The planner mutates a copy of
+// weekLoad internally for scoring this day's picks and returns the
+// resulting Session. Returns errNoExercisesForCategory (wrapped) if
+// the derived category has no compatible exercises.
+func (wp *Planner) PlanDay(
+	date time.Time,
+	weekUsedExerciseIDs map[int]bool,
+	weekLoad map[string]float64,
+) (Session, error) {
 	category := wp.determineCategory(date)
 	if !wp.hasExercisesForCategory(category) {
 		return Session{}, fmt.Errorf(
-			"%w: %s day (%s)", errNoExercisesForCategory, category, date.Weekday())
+			"%w: %s day (%s)", errNoExercisesForCategory, category, date.Weekday(),
+		)
 	}
 
-	// Periodization: replicate the weekly planner's per-day alternation.
-	// Count scheduled prefs days strictly before date.Weekday() in Mon-first
-	// week order. Iterating Mon..Sat explicitly (rather than as an int range)
-	// handles Sunday correctly: time.Sunday = 0 < time.Monday = 1, so an int
-	// range would never count anything for a Sunday date.
 	idx := 0
 	target := date.Weekday()
 	for _, d := range []time.Weekday{
@@ -139,21 +143,17 @@ func (wp *Planner) PlanDay(date time.Time, weekUsedExerciseIDs map[int]bool) (Se
 			idx++
 		}
 	}
-	// Sunday never matches any d above, so it falls through with the full count
-	// of scheduled Mon..Sat days — exactly the index workoutDays[i==len-1] would
-	// have produced for it.
 	monday := MondayOf(date)
 	firstPT := wp.firstSessionPeriodizationType(monday)
 	pt := nextPeriodizationType(firstPT, idx)
 
-	isDeload := IsDeloadWeek(monday, wp.Prefs.MesocycleAnchor, wp.Prefs.MesocycleLength, wp.Prefs.DeloadEnabled)
+	isDeload := IsDeloadWeek(
+		monday, wp.Prefs.MesocycleAnchor, wp.Prefs.MesocycleLength, wp.Prefs.DeloadEnabled,
+	)
 	if isDeload {
 		pt = PeriodizationHypertrophy
 	}
 
-	// Exercise count: from prefs if the day is scheduled, otherwise medium
-	// (bumped to medium-hypertrophy when the ad-hoc day is hypertrophy and
-	// not deload, matching the scheduled-day rule).
 	n := exercisesPerSession(wp.Prefs, date.Weekday(), pt, isDeload)
 	if n == 0 {
 		n = exercisesMedium
@@ -164,18 +164,17 @@ func (wp *Planner) PlanDay(date time.Time, weekUsedExerciseIDs map[int]bool) (Se
 
 	used := weekUsedExerciseIDs
 	if used == nil {
-		used = make(map[int]bool)
+		used = map[int]bool{}
 	}
-	load := map[string]float64{}
-	exerciseSlots := wp.selectExercisesForDayWithPeriodization(
-		category, n, pt, isDeload, used, load,
-	)
+	load := make(map[string]float64, len(weekLoad))
+	maps.Copy(load, weekLoad)
+	slots := wp.selectExercisesForDayWithPeriodization(category, n, pt, isDeload, used, load)
 
-	return Session{ //nolint:exhaustruct // DifficultyRating, StartedAt, CompletedAt start zero.
+	return Session{ //nolint:exhaustruct // DifficultyRating/StartedAt/CompletedAt start zero.
 		Date:              date,
 		PeriodizationType: pt,
 		IsDeload:          isDeload,
-		Slots:             exerciseSlots,
+		Slots:             slots,
 	}, nil
 }
 

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 )
 
@@ -17,8 +16,7 @@ const (
 	exercisesMediumHypertrophy = 4
 	exercisesShort             = 2
 
-	maxMuscleGroupDaysPerWeek = 2
-	numPeriodizationTypes     = 2
+	numPeriodizationTypes = 2
 
 	hoursPerDay = 24
 )
@@ -54,9 +52,6 @@ func (wp *Planner) Plan(startingDate time.Time) (WeekPlan, error) {
 		return WeekPlan{}, fmt.Errorf("startingDate must be a Monday, got %s", startingDate.Weekday())
 	}
 
-	// Pre-fill all 7 slots with rest-day placeholders. Scheduled days
-	// overwrite their slot below; the rest carry only their Date so
-	// WeekPlan.SessionOn returns a valid pointer for every day of the week.
 	result := WeekPlan{
 		Monday:   startingDate,
 		Sessions: [7]Session{},
@@ -67,7 +62,6 @@ func (wp *Planner) Plan(startingDate time.Time) (WeekPlan, error) {
 		}
 	}
 
-	// Collect scheduled workout days Mon–Sun.
 	var workoutDays []time.Time
 	for i := range 7 {
 		day := startingDate.AddDate(0, 0, i)
@@ -79,51 +73,35 @@ func (wp *Planner) Plan(startingDate time.Time) (WeekPlan, error) {
 		return WeekPlan{}, errors.New("no workout days scheduled in preferences")
 	}
 
-	// Phase 1: determine category for each scheduled day.
-	categories := make(map[time.Time]Category, len(workoutDays))
 	for _, day := range workoutDays {
 		cat := wp.determineCategory(day)
 		if !wp.hasExercisesForCategory(cat) {
 			return WeekPlan{}, fmt.Errorf("%w: %s day (%s)", errNoExercisesForCategory, cat, day.Weekday())
 		}
-		categories[day] = cat
 	}
 
-	// Phase 2: allocate muscle group slots across days.
-	dayMuscleGroups := wp.allocateMuscleGroups(workoutDays, categories)
-
-	// Determine periodization type for first session.
 	firstPT := wp.firstSessionPeriodizationType(startingDate)
-	isDeload := IsDeloadWeek(startingDate, wp.Prefs.MesocycleAnchor, wp.Prefs.MesocycleLength, wp.Prefs.DeloadEnabled)
+	isDeload := IsDeloadWeek(
+		startingDate, wp.Prefs.MesocycleAnchor, wp.Prefs.MesocycleLength, wp.Prefs.DeloadEnabled,
+	)
 
-	// Phase 3: select exercises and write into the day-indexed slot.
-	weekUsedExercises := make(map[int]bool)
+	weekUsedExercises := map[int]bool{}
+	load := map[string]float64{}
 	for i, day := range workoutDays {
 		pt := nextPeriodizationType(firstPT, i)
 		if isDeload {
 			pt = PeriodizationHypertrophy
 		}
 		n := exercisesPerSession(wp.Prefs, day.Weekday(), pt, isDeload)
-		exerciseSlots := wp.selectExercisesForDayWithPeriodization(
-			categories[day],
-			dayMuscleGroups[day],
-			n,
-			pt,
-			isDeload,
-			weekUsedExercises,
+		slots := wp.selectExercisesForDayWithPeriodization(
+			wp.determineCategory(day), n, pt, isDeload, weekUsedExercises, load,
 		)
-
-		// Record which exercises were used this week.
-		for _, es := range exerciseSlots {
-			weekUsedExercises[es.Exercise.ID] = true
-		}
-
 		dayOffset := int(day.Sub(startingDate).Hours() / hoursPerDay)
-		result.Sessions[dayOffset] = Session{ //nolint:exhaustruct // DifficultyRating, StartedAt, CompletedAt start zero.
+		result.Sessions[dayOffset] = Session{ //nolint:exhaustruct // DifficultyRating/StartedAt/CompletedAt start zero.
 			Date:              day,
 			PeriodizationType: pt,
 			IsDeload:          isDeload,
-			Slots:             exerciseSlots,
+			Slots:             slots,
 		}
 	}
 
@@ -188,8 +166,9 @@ func (wp *Planner) PlanDay(date time.Time, weekUsedExerciseIDs map[int]bool) (Se
 	if used == nil {
 		used = make(map[int]bool)
 	}
+	load := map[string]float64{}
 	exerciseSlots := wp.selectExercisesForDayWithPeriodization(
-		category, nil, n, pt, isDeload, used,
+		category, n, pt, isDeload, used, load,
 	)
 
 	return Session{ //nolint:exhaustruct // DifficultyRating, StartedAt, CompletedAt start zero.
@@ -265,84 +244,6 @@ func isCategoryCompatible(exerciseCategory, dayCategory Category) bool {
 	return exerciseCategory == dayCategory
 }
 
-// hasCategoryExerciseForMuscleGroup reports whether the pool contains at least
-// one exercise compatible with dayCategory whose primary muscles include muscleGroup.
-func (wp *Planner) hasCategoryExerciseForMuscleGroup(dayCategory Category, muscleGroup string) bool {
-	for _, ex := range wp.Exercises {
-		if !isCategoryCompatible(ex.Category, dayCategory) {
-			continue
-		}
-		if slices.Contains(ex.PrimaryMuscleGroups, muscleGroup) {
-			return true
-		}
-	}
-	return false
-}
-
-// allocateMuscleGroups assigns each tracked muscle group to up to 2 workout days
-// using a most-constrained-first greedy algorithm. A muscle group is valid for a
-// day if at least one compatible exercise targets it as a primary muscle.
-func (wp *Planner) allocateMuscleGroups(
-	workoutDays []time.Time,
-	categories map[time.Time]Category,
-) map[time.Time][]string {
-	// Build valid-day lists for each muscle group.
-	type mgEntry struct {
-		name      string
-		validDays []time.Time
-	}
-	entries := make([]mgEntry, len(wp.Targets))
-	for i, target := range wp.Targets {
-		var valid []time.Time
-		for _, day := range workoutDays {
-			if wp.hasCategoryExerciseForMuscleGroup(categories[day], target.MuscleGroupName) {
-				valid = append(valid, day)
-			}
-		}
-		entries[i] = mgEntry{name: target.MuscleGroupName, validDays: valid}
-	}
-
-	// Sort ascending by number of valid days (most constrained first).
-	// Alphabetical name as tiebreaker for determinism.
-	slices.SortFunc(entries, func(a, b mgEntry) int {
-		if len(a.validDays) != len(b.validDays) {
-			return len(a.validDays) - len(b.validDays)
-		}
-		if a.name < b.name {
-			return -1
-		}
-		if a.name > b.name {
-			return 1
-		}
-		return 0
-	})
-
-	assignmentCount := make(map[time.Time]int)
-	result := make(map[time.Time][]string)
-
-	for _, entry := range entries {
-		if len(entry.validDays) == 0 {
-			continue
-		}
-
-		// Sort valid days by current assignment count (least loaded first).
-		sortedDays := slices.Clone(entry.validDays)
-		slices.SortFunc(sortedDays, func(a, b time.Time) int {
-			return assignmentCount[a] - assignmentCount[b]
-		})
-
-		// Assign to up to maxMuscleGroupDaysPerWeek days.
-		limit := min(maxMuscleGroupDaysPerWeek, len(sortedDays))
-		for i := range limit {
-			day := sortedDays[i]
-			result[day] = append(result[day], entry.name)
-			assignmentCount[day]++
-		}
-	}
-
-	return result
-}
-
 // primaryMuscleGroupsOverlap returns true if any of the exercise's primary muscle groups
 // are already in the selectedPrimaryMuscles set.
 func primaryMuscleGroupsOverlap(ex Exercise, selectedPrimaryMuscles map[string]bool) bool {
@@ -382,26 +283,7 @@ func (wp *Planner) selectExercisesForDayWithPeriodization(
 	selected := make([]ExerciseSlot, 0, n)
 
 	for len(selected) < n {
-		bestIdx := -1
-		bestScore := 0.0
-		for i := range wp.Exercises {
-			ex := wp.Exercises[i]
-			if !isCategoryCompatible(ex.Category, category) {
-				continue
-			}
-			if weekUsedExercises[ex.ID] {
-				continue
-			}
-			if primaryMuscleGroupsOverlap(ex, selectedPrimaryMGs) {
-				continue
-			}
-			score := scoreCandidate(ex, pt, isDeload, load, targets)
-			if bestIdx < 0 || score > bestScore ||
-				(score == bestScore && ex.ID < wp.Exercises[bestIdx].ID) {
-				bestIdx = i
-				bestScore = score
-			}
-		}
+		bestIdx := wp.pickBestExerciseIdx(category, pt, isDeload, selectedPrimaryMGs, weekUsedExercises, load, targets)
 		if bestIdx < 0 {
 			break
 		}
@@ -412,16 +294,54 @@ func (wp *Planner) selectExercisesForDayWithPeriodization(
 			selectedPrimaryMGs[mg] = true
 		}
 		weekUsedExercises[ex.ID] = true
-		nSets := float64(len(slot.Sets))
-		for _, mg := range ex.PrimaryMuscleGroups {
-			load[mg] += nSets * PrimarySetWeight
-		}
-		for _, mg := range ex.SecondaryMuscleGroups {
-			load[mg] += nSets * SecondarySetWeight
-		}
+		applyLoad(load, ex, float64(len(slot.Sets)))
 	}
 
 	return selected
+}
+
+// pickBestExerciseIdx returns the index into wp.Exercises of the exercise that
+// maximises scoreCandidate among candidates that are category-compatible,
+// not already used this week, and don't share a primary MG with selectedPrimaryMGs.
+// Ties are broken by lowest exercise ID. Returns -1 if no candidate qualifies.
+func (wp *Planner) pickBestExerciseIdx(
+	category Category,
+	pt PeriodizationType,
+	isDeload bool,
+	selectedPrimaryMGs map[string]bool,
+	weekUsedExercises map[int]bool,
+	load map[string]float64,
+	targets map[string]int,
+) int {
+	bestIdx := -1
+	bestScore := 0.0
+	for i := range wp.Exercises {
+		ex := wp.Exercises[i]
+		if !isCategoryCompatible(ex.Category, category) ||
+			weekUsedExercises[ex.ID] ||
+			primaryMuscleGroupsOverlap(ex, selectedPrimaryMGs) {
+			continue
+		}
+		score := scoreCandidate(ex, pt, isDeload, load, targets)
+		if bestIdx < 0 || score > bestScore ||
+			(score == bestScore && ex.ID < wp.Exercises[bestIdx].ID) {
+			bestIdx = i
+			bestScore = score
+		}
+	}
+	return bestIdx
+}
+
+// applyLoad accumulates the per-set MG contribution from ex into load:
+// PrimarySetWeight per primary MG, SecondarySetWeight per secondary, scaled
+// by nSets. Mutates load in place.
+func applyLoad(load map[string]float64, ex Exercise, nSets float64) {
+	for _, mg := range ex.PrimaryMuscleGroups {
+		load[mg] += nSets * PrimarySetWeight
+	}
+	for _, mg := range ex.SecondaryMuscleGroups {
+		load[mg] += nSets * SecondarySetWeight
+	}
 }
 
 // buildPlannedExerciseSlot creates an ExerciseSlot for one exercise using

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -503,6 +503,39 @@ func nextPeriodizationType(first PeriodizationType, idx int) PeriodizationType {
 	return PeriodizationStrength
 }
 
+// scoreCandidate returns the gain in target-balance from adding ex to a
+// session: positive when the exercise pulls the running per-MG load
+// closer to its target, negative when it pushes an MG further from
+// target. The metric is the change in the sum of squared distances
+// over targeted muscle groups; untargeted MGs are ignored. Set count
+// comes from the same deriveSchemeForExercise the planner uses to
+// persist sets, so deload halving and periodization-driven set-count
+// shifts are reflected automatically.
+func scoreCandidate(
+	ex Exercise,
+	pt PeriodizationType, //nolint:unparam // upcoming selection loop passes hypertrophy sessions too.
+	isDeload bool,
+	load map[string]float64,
+	targets map[string]int,
+) float64 {
+	_, nSets := deriveSchemeForExercise(ex, pt, isDeload)
+	n := float64(nSets)
+	contrib := make(map[string]float64, len(ex.PrimaryMuscleGroups)+len(ex.SecondaryMuscleGroups))
+	for _, mg := range ex.PrimaryMuscleGroups {
+		contrib[mg] += n * PrimarySetWeight
+	}
+	for _, mg := range ex.SecondaryMuscleGroups {
+		contrib[mg] += n * SecondarySetWeight
+	}
+	var delta float64
+	for mg, target := range targets {
+		before := float64(target) - load[mg]
+		after := before - contrib[mg]
+		delta += before*before - after*after
+	}
+	return delta
+}
+
 // MondayOf returns the Monday of the week containing date, at 00:00 UTC.
 // The calendar date is taken from date's own location so the user's local
 // week boundary is preserved, but the result is anchored to UTC so it

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -53,6 +53,9 @@ func (wp *Planner) Plan(startingDate time.Time) (WeekPlan, error) {
 		return WeekPlan{}, fmt.Errorf("startingDate must be a Monday, got %s", startingDate.Weekday())
 	}
 
+	// Pre-fill all 7 slots with rest-day placeholders. Scheduled days
+	// overwrite their slot below; the rest carry only their Date so
+	// WeekPlan.SessionOn returns a valid pointer for every day of the week.
 	result := WeekPlan{
 		Monday:   startingDate,
 		Sessions: [7]Session{},
@@ -136,6 +139,12 @@ func (wp *Planner) PlanDay(
 		)
 	}
 
+	// Count scheduled prefs days strictly before date.Weekday() in Mon-first
+	// week order. Iterating Mon..Sat explicitly (rather than as an int range)
+	// handles Sunday correctly: time.Sunday = 0 < time.Monday = 1, so an int
+	// range would never count anything for a Sunday date. Sunday falls
+	// through the loop with the full Mon..Sat count — exactly the index
+	// workoutDays[i==len-1] would have produced for it in Plan.
 	idx := 0
 	target := date.Weekday()
 	for _, d := range []time.Weekday{

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -354,121 +354,73 @@ func primaryMuscleGroupsOverlap(ex Exercise, selectedPrimaryMuscles map[string]b
 	return false
 }
 
-// scoreExerciseForPriority scores an exercise by how many unsatisfied priority muscle groups it covers.
-func scoreExerciseForPriority(ex Exercise, priorityMuscleGroups []string, satisfied map[string]bool) int {
-	score := 0
-	for _, mg := range ex.PrimaryMuscleGroups {
-		if slices.Contains(priorityMuscleGroups, mg) && !satisfied[mg] {
-			score++
-		}
-	}
-	return score
-}
-
-// findBestExerciseInPool finds the highest-scoring exercise from the pool that doesn't conflict.
-// Returns the index in pool, or -1 if no suitable exercise found.
-func (wp *Planner) findBestExerciseInPool(
-	pool []Exercise,
-	priorityMuscleGroups []string,
-	selectedPrimaryMuscles map[string]bool,
-	weekUsedExercises map[int]bool,
-) int {
-	bestScore := -1
-	bestIdx := -1
-
-	for i := range pool {
-		if weekUsedExercises[pool[i].ID] || primaryMuscleGroupsOverlap(pool[i], selectedPrimaryMuscles) {
-			continue
-		}
-
-		score := scoreExerciseForPriority(pool[i], priorityMuscleGroups, selectedPrimaryMuscles)
-		if score > bestScore {
-			bestScore = score
-			bestIdx = i
-		}
-	}
-
-	return bestIdx
-}
-
-// selectAndRemoveFromPool selects an exercise from the pool and removes it.
-func selectAndRemoveFromPool(pool *[]Exercise, idx int, selectedPrimaryMuscles map[string]bool) Exercise {
-	ex := (*pool)[idx]
-	for _, mg := range ex.PrimaryMuscleGroups {
-		selectedPrimaryMuscles[mg] = true
-	}
-	*pool = append((*pool)[:idx], (*pool)[idx+1:]...)
-	return ex
-}
-
-// selectExercisesForDay picks n exercises for a day via category-filtered, score-based
-// greedy selection. Uses Strength periodization by default.
-func (wp *Planner) selectExercisesForDay(
-	category Category,
-	priorityMuscleGroups []string,
-	n int,
-) []ExerciseSlot {
-	return wp.selectExercisesForDayWithPeriodization(
-		category,
-		priorityMuscleGroups,
-		n,
-		PeriodizationStrength,
-		false,
-		make(map[int]bool),
-	)
-}
-
+// selectExercisesForDayWithPeriodization picks up to n category-compatible
+// exercises for a session, mutating load with each pick's primary
+// (PrimarySetWeight) and secondary (SecondarySetWeight) contributions
+// and marking each picked exercise's ID in weekUsedExercises so later
+// days in the same week skip it. The chosen exercise on every slot is
+// the one that maximises scoreCandidate against the current load and
+// the planner's Targets, with the lowest exercise ID winning ties.
+// Within a session, exercises whose primary MGs overlap with already
+// selected primaries are skipped (no two chest-primary picks in one
+// session). When no eligible candidate remains, selection stops early
+// (graceful degradation: the session may have fewer than n slots).
 func (wp *Planner) selectExercisesForDayWithPeriodization(
 	category Category,
-	priorityMuscleGroups []string,
 	n int,
 	pt PeriodizationType,
 	isDeload bool,
 	weekUsedExercises map[int]bool,
+	load map[string]float64,
 ) []ExerciseSlot {
-	// Filter exercise pool by category compatibility.
-	pool := make([]Exercise, 0, len(wp.Exercises))
-	for _, ex := range wp.Exercises {
-		if isCategoryCompatible(ex.Category, category) {
-			pool = append(pool, ex)
-		}
+	targets := make(map[string]int, len(wp.Targets))
+	for _, t := range wp.Targets {
+		targets[t.MuscleGroupName] = t.WeeklySetTarget
 	}
 
-	selectedPrimaryMuscles := make(map[string]bool)
-	var selected []Exercise
+	selectedPrimaryMGs := make(map[string]bool)
+	selected := make([]ExerciseSlot, 0, n)
 
-	// Phase A: Try to satisfy each priority muscle group with a non-conflicting exercise.
-	for _, priorityMG := range priorityMuscleGroups {
-		if len(selected) >= n || selectedPrimaryMuscles[priorityMG] {
-			continue
+	for len(selected) < n {
+		bestIdx := -1
+		bestScore := 0.0
+		for i := range wp.Exercises {
+			ex := wp.Exercises[i]
+			if !isCategoryCompatible(ex.Category, category) {
+				continue
+			}
+			if weekUsedExercises[ex.ID] {
+				continue
+			}
+			if primaryMuscleGroupsOverlap(ex, selectedPrimaryMGs) {
+				continue
+			}
+			score := scoreCandidate(ex, pt, isDeload, load, targets)
+			if bestIdx < 0 || score > bestScore {
+				bestIdx = i
+				bestScore = score
+			}
 		}
-
-		bestIdx := wp.findBestExerciseInPool(pool, priorityMuscleGroups, selectedPrimaryMuscles, weekUsedExercises)
-		if bestIdx >= 0 {
-			ex := selectAndRemoveFromPool(&pool, bestIdx, selectedPrimaryMuscles)
-			selected = append(selected, ex)
-		}
-	}
-
-	// Phase B: Fill remaining slots with any non-conflicting exercise from the pool.
-	for len(selected) < n && len(pool) > 0 {
-		bestIdx := wp.findBestExerciseInPool(pool, priorityMuscleGroups, selectedPrimaryMuscles, weekUsedExercises)
 		if bestIdx < 0 {
 			break
 		}
-
-		ex := selectAndRemoveFromPool(&pool, bestIdx, selectedPrimaryMuscles)
-		selected = append(selected, ex)
+		ex := wp.Exercises[bestIdx]
+		slot := buildPlannedExerciseSlot(ex, pt, isDeload)
+		selected = append(selected, slot)
+		for _, mg := range ex.PrimaryMuscleGroups {
+			selectedPrimaryMGs[mg] = true
+		}
+		weekUsedExercises[ex.ID] = true
+		nSets := float64(len(slot.Sets))
+		for _, mg := range ex.PrimaryMuscleGroups {
+			load[mg] += nSets * PrimarySetWeight
+		}
+		for _, mg := range ex.SecondaryMuscleGroups {
+			load[mg] += nSets * SecondarySetWeight
+		}
 	}
 
-	// Build Slots. Time-based exercises use their own
-	// DefaultStartingSeconds with a fixed set count; rep-based exercises
-	// derive their full prescription from the per-exercise window via DeriveScheme.
-	result := make([]ExerciseSlot, len(selected))
-	for i, ex := range selected {
-		result[i] = buildPlannedExerciseSlot(ex, pt, isDeload)
-	}
-	return result
+	return selected
 }
 
 // buildPlannedExerciseSlot creates an ExerciseSlot for one exercise using
@@ -513,7 +465,7 @@ func nextPeriodizationType(first PeriodizationType, idx int) PeriodizationType {
 // shifts are reflected automatically.
 func scoreCandidate(
 	ex Exercise,
-	pt PeriodizationType, //nolint:unparam // upcoming selection loop passes hypertrophy sessions too.
+	pt PeriodizationType,
 	isDeload bool,
 	load map[string]float64,
 	targets map[string]int,

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -114,10 +114,16 @@ func (wp *Planner) Plan(startingDate time.Time) (WeekPlan, error) {
 // after Plan(monday) already ran). weekUsedExerciseIDs is the set of
 // exercise IDs already used in other sessions this week; weekLoad is
 // the running per-MG weighted load from those sessions (built by the
-// caller via WeeklyPlannedLoad). The planner mutates a copy of
-// weekLoad internally for scoring this day's picks and returns the
-// resulting Session. Returns errNoExercisesForCategory (wrapped) if
-// the derived category has no compatible exercises.
+// caller via WeeklyPlannedLoad).
+//
+// weekLoad is copied internally before scoring this day's picks, so
+// the caller's map is not mutated. weekUsedExerciseIDs is NOT copied —
+// the selection loop adds this day's picked IDs to it so a single
+// shared map can be threaded through multiple PlanDay calls in the
+// same week. Pass a fresh map if you don't want this side effect.
+//
+// Returns errNoExercisesForCategory (wrapped) if the derived category
+// has no compatible exercises.
 func (wp *Planner) PlanDay(
 	date time.Time,
 	weekUsedExerciseIDs map[int]bool,
@@ -322,6 +328,10 @@ func (wp *Planner) pickBestExerciseIdx(
 			continue
 		}
 		score := scoreCandidate(ex, pt, isDeload, load, targets)
+		// Exact float equality is safe here: scores are derived from
+		// integer targets, integer set counts, and fixed half-integer
+		// weights (PrimarySetWeight, SecondarySetWeight), so ties round-trip
+		// cleanly through IEEE 754.
 		if bestIdx < 0 || score > bestScore ||
 			(score == bestScore && ex.ID < wp.Exercises[bestIdx].ID) {
 			bestIdx = i
@@ -378,8 +388,11 @@ func nextPeriodizationType(first PeriodizationType, idx int) PeriodizationType {
 // scoreCandidate returns the gain in target-balance from adding ex to a
 // session: positive when the exercise pulls the running per-MG load
 // closer to its target, negative when it pushes an MG further from
-// target. The metric is the change in the sum of squared distances
-// over targeted muscle groups; untargeted MGs are ignored. Set count
+// target. An MG that is already over target contributes negatively
+// proportional to how far it would overshoot — picks that re-load an
+// already-saturated MG score lower than picks that touch fresh ground.
+// The metric is the change in the sum of squared distances over
+// targeted muscle groups; untargeted MGs are ignored. Set count
 // comes from the same deriveSchemeForExercise the planner uses to
 // persist sets, so deload halving and periodization-driven set-count
 // shifts are reflected automatically.

--- a/internal/domain/planner.go
+++ b/internal/domain/planner.go
@@ -396,7 +396,8 @@ func (wp *Planner) selectExercisesForDayWithPeriodization(
 				continue
 			}
 			score := scoreCandidate(ex, pt, isDeload, load, targets)
-			if bestIdx < 0 || score > bestScore {
+			if bestIdx < 0 || score > bestScore ||
+				(score == bestScore && ex.ID < wp.Exercises[bestIdx].ID) {
 				bestIdx = i
 				bestScore = score
 			}

--- a/internal/domain/planner_internal_test.go
+++ b/internal/domain/planner_internal_test.go
@@ -240,20 +240,24 @@ func TestAllocateMuscleGroups(t *testing.T) {
 	}
 }
 
-func TestSelectExercisesForDay(t *testing.T) {
+func TestSelectExercises_CategoryFilter(t *testing.T) {
 	t.Parallel()
 
-	p := prefs(time.Monday, time.Tuesday, time.Thursday)
+	p := prefs(time.Tuesday)
 	wp := NewPlanner(p, minimalExercises(), minimalTargets())
 
 	t.Run("lower day only selects lower exercises", func(t *testing.T) {
 		t.Parallel()
-		sets := wp.selectExercisesForDay(CategoryLower, []string{"Quads", "Hamstrings"}, 2)
-		if len(sets) != 2 {
-			t.Fatalf("want 2 exercise sets, got %d", len(sets))
+		load := map[string]float64{}
+		used := map[int]bool{}
+		slots := wp.selectExercisesForDayWithPeriodization(
+			CategoryLower, 2, PeriodizationStrength, false, used, load,
+		)
+		if len(slots) != 2 {
+			t.Fatalf("want 2 slots, got %d", len(slots))
 		}
-		for _, es := range sets {
-			ex := findExercise(wp.Exercises, es.Exercise.ID)
+		for _, s := range slots {
+			ex := findExercise(wp.Exercises, s.Exercise.ID)
 			if ex.Category != CategoryLower {
 				t.Errorf("lower day got exercise with category %s", ex.Category)
 			}
@@ -262,9 +266,13 @@ func TestSelectExercisesForDay(t *testing.T) {
 
 	t.Run("upper day only selects upper exercises", func(t *testing.T) {
 		t.Parallel()
-		sets := wp.selectExercisesForDay(CategoryUpper, []string{"Chest", "Lats"}, 2)
-		for _, es := range sets {
-			ex := findExercise(wp.Exercises, es.Exercise.ID)
+		load := map[string]float64{}
+		used := map[int]bool{}
+		slots := wp.selectExercisesForDayWithPeriodization(
+			CategoryUpper, 2, PeriodizationStrength, false, used, load,
+		)
+		for _, s := range slots {
+			ex := findExercise(wp.Exercises, s.Exercise.ID)
 			if ex.Category != CategoryUpper {
 				t.Errorf("upper day got exercise with category %s", ex.Category)
 			}
@@ -273,282 +281,63 @@ func TestSelectExercisesForDay(t *testing.T) {
 
 	t.Run("full body day can select any category", func(t *testing.T) {
 		t.Parallel()
-		sets := wp.selectExercisesForDay(CategoryFullBody, []string{"Hamstrings", "Chest"}, 3)
-		categorySet := make(map[Category]bool)
-		for _, es := range sets {
-			ex := findExercise(wp.Exercises, es.Exercise.ID)
-			categorySet[ex.Category] = true
+		load := map[string]float64{}
+		used := map[int]bool{}
+		slots := wp.selectExercisesForDayWithPeriodization(
+			CategoryFullBody, 3, PeriodizationStrength, false, used, load,
+		)
+		seen := map[Category]bool{}
+		for _, s := range slots {
+			ex := findExercise(wp.Exercises, s.Exercise.ID)
+			seen[ex.Category] = true
 		}
-		// With Hamstrings and Chest as priorities, expect both lower and upper exercises selected.
-		if !categorySet[CategoryLower] || !categorySet[CategoryUpper] {
-			t.Error("full body day should draw from multiple categories when priorities span both")
-		}
-	})
-
-	t.Run("rep-based exercise set count comes from DeriveScheme", func(t *testing.T) {
-		t.Parallel()
-		sets := wp.selectExercisesForDay(CategoryUpper, []string{"Chest"}, 1)
-		if len(sets) != 1 {
-			t.Fatalf("want 1 exercise set, got %d", len(sets))
-		}
-		// With Strength + window 5-10, DeriveScheme returns 4 sets (reps=5 ≤ 5).
-		expectedSets := DeriveScheme(5, 10, PeriodizationStrength, false).TargetSets
-		if len(sets[0].Sets) != expectedSets {
-			t.Errorf("want %d sets, got %d", expectedSets, len(sets[0].Sets))
-		}
-	})
-
-	t.Run("strength periodization sets correct target value", func(t *testing.T) {
-		t.Parallel()
-		sets := wp.selectExercisesForDay(CategoryUpper, nil, 1)
-		expectedReps := DeriveScheme(5, 10, PeriodizationStrength, false).TargetReps
-		for _, s := range sets[0].Sets {
-			if s.TargetValue != expectedReps {
-				t.Errorf("strength set: want TargetValue=%d, got %d", expectedReps, s.TargetValue)
-			}
+		if !seen[CategoryLower] || !seen[CategoryUpper] {
+			t.Error("full body day should draw from multiple categories with targets across both")
 		}
 	})
 }
 
-func TestSelectExercisesForDaySessionDiversity(t *testing.T) {
+func TestSelectExercises_SessionDiversity(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no primary muscle group overlap within session", func(t *testing.T) {
+	t.Run("no primary muscle group repeats within a session", func(t *testing.T) {
 		t.Parallel()
-		// Exercise pool: multiple exercises that could target overlapping muscles.
+		// Three Chest-primary exercises in the pool; we ask for 3 slots.
+		// Only one can be picked (no primary overlap); the other 2 must come
+		// from non-Chest primaries (Triceps-only exercise).
 		exercises := []Exercise{
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Triceps"},
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Shoulders"},
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Shoulders", "Triceps"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 4, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Triceps"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-		}
-
-		p := prefs(time.Tuesday) // 3 exercises
-		wp := NewPlanner(p, exercises, nil)
-
-		// Request 3 exercises with priority Chest, Shoulders, Triceps.
-		// Expected: one exercise per primary muscle group, no overlaps.
-		sets := wp.selectExercisesForDayWithPeriodization(
-			CategoryUpper,
-			[]string{"Chest", "Shoulders", "Triceps"},
-			3,
-			PeriodizationStrength,
-			false,
-			make(map[int]bool), // Empty week-used set.
-		)
-
-		if len(sets) < 2 {
-			t.Fatalf("want at least 2 exercises, got %d", len(sets))
-		}
-
-		// Collect all primary muscle groups across selected exercises.
-		seenPrimary := make(map[string]bool)
-		for _, es := range sets {
-			ex := findExercise(exercises, es.Exercise.ID)
-			for _, mg := range ex.PrimaryMuscleGroups {
-				if seenPrimary[mg] {
-					t.Errorf("primary muscle group %q appears in multiple exercises in the same session", mg)
-				}
-				seenPrimary[mg] = true
-			}
-		}
-	})
-
-	t.Run("skip priority muscle group when no non-conflicting exercise available", func(t *testing.T) {
-		t.Parallel()
-		// Exercise pool: all Chest exercises have overlapping primary muscles.
-		exercises := []Exercise{
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
+			{ //nolint:exhaustruct // Test exercises omit display fields.
 				ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
+				RepMin: new(5), RepMax: new(10),
+			},
+			{ //nolint:exhaustruct // Test exercises omit display fields.
 				ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 				PrimaryMuscleGroups: []string{"Chest", "Triceps"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest", "Shoulders"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-		}
-
-		p := prefs(time.Tuesday) // 3 exercises
-		wp := NewPlanner(p, exercises, nil)
-
-		// Request 3 exercises, but only 1 non-overlapping is available.
-		// Expected: graceful degradation — select 1 exercise covering Chest.
-		sets := wp.selectExercisesForDayWithPeriodization(
-			CategoryUpper,
-			[]string{"Chest", "Shoulders", "Triceps"}, // Three priorities, but can't all be satisfied.
-			3,
-			PeriodizationStrength,
-			false,
-			make(map[int]bool),
-		)
-
-		if len(sets) == 0 {
-			t.Fatalf("want at least 1 exercise, got 0")
-		}
-
-		// Should select 1 exercise (Chest), then can't add more without overlap.
-		if len(sets) > 1 {
-			// Check that no primary muscle groups repeat.
-			seenPrimary := make(map[string]bool)
-			for _, es := range sets {
-				ex := findExercise(exercises, es.Exercise.ID)
-				for _, mg := range ex.PrimaryMuscleGroups {
-					if seenPrimary[mg] {
-						t.Errorf(
-							"primary muscle group %q appears twice; expected graceful degradation to 1 exercise",
-							mg,
-						)
-					}
-					seenPrimary[mg] = true
-				}
-			}
-		}
-	})
-}
-
-func TestSelectExercisesForDayWeekDeduplication(t *testing.T) {
-	t.Parallel()
-
-	t.Run("exercise used earlier in week is skipped", func(t *testing.T) {
-		t.Parallel()
-		exercises := []Exercise{
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
+				RepMin: new(5), RepMax: new(10),
+			},
+			{ //nolint:exhaustruct // Test exercises omit display fields.
 				ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 				PrimaryMuscleGroups: []string{"Triceps"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
+				RepMin: new(5), RepMax: new(10),
+			},
 		}
-
-		p := prefs(time.Tuesday)
-		wp := NewPlanner(p, exercises, nil)
-
-		// Simulate that exercise 1 was already used earlier in the week.
-		weekUsedExercises := map[int]bool{1: true}
-
-		// Request exercises with Chest priority, but exercise 1 (Chest) is already used.
-		// Expected: select exercise 2 (Shoulders) or 3 (Triceps) instead.
-		sets := wp.selectExercisesForDayWithPeriodization(
-			CategoryUpper,
-			[]string{"Chest"},
-			1,
-			PeriodizationStrength,
-			false,
-			weekUsedExercises,
+		wp := NewPlanner(prefs(time.Tuesday), exercises, []MuscleGroupTarget{
+			{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+			{MuscleGroupName: "Triceps", WeeklySetTarget: 8},
+		})
+		load := map[string]float64{}
+		used := map[int]bool{}
+		slots := wp.selectExercisesForDayWithPeriodization(
+			CategoryUpper, 3, PeriodizationStrength, false, used, load,
 		)
 
-		if len(sets) == 0 {
-			t.Fatalf("want 1 exercise, got 0")
-		}
-
-		selectedID := sets[0].Exercise.ID
-		if selectedID == 1 {
-			t.Errorf("exercise 1 was already used this week; expected a different exercise, got %d", selectedID)
-		}
-	})
-
-	t.Run("plan() does not repeat exercises across days", func(t *testing.T) {
-		t.Parallel()
-		exercises := minimalExercises() // Use existing test fixture.
-		targets := minimalTargets()
-
-		monday := monday2026Date()
-		p := prefs(time.Monday, time.Tuesday, time.Thursday)
-		wp := NewPlanner(p, exercises, targets)
-
-		plan, err := wp.Plan(monday)
-		if err != nil {
-			t.Fatalf("Plan failed: %v", err)
-		}
-		var sessions []Session
-		for i := range plan.Sessions {
-			if len(plan.Sessions[i].Slots) > 0 {
-				sessions = append(sessions, plan.Sessions[i])
-			}
-		}
-
-		// Collect all exercise IDs across all sessions.
-		usedExercises := make(map[int]bool)
-		for _, session := range sessions {
-			for _, es := range session.Slots {
-				if usedExercises[es.Exercise.ID] {
-					t.Errorf("exercise %d appears in multiple sessions across the week", es.Exercise.ID)
-				}
-				usedExercises[es.Exercise.ID] = true
-			}
-		}
-
-		// Verify that we have more than one session (to make the test meaningful).
-		if len(sessions) < 2 {
-			t.Logf("note: only %d session(s) planned, test less meaningful", len(sessions))
-		}
-	})
-}
-
-func TestSelectExercisesForDayGracefulDegradation(t *testing.T) {
-	t.Parallel()
-
-	t.Run("returns fewer exercises if constraints can't be fully satisfied", func(t *testing.T) {
-		t.Parallel()
-		// Exercise pool: only 2 non-overlapping exercises available.
-		exercises := []Exercise{
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-			{ //nolint:exhaustruct // Test exercises omit unused display fields.
-				ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-				PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
-				DefaultStartingSeconds: nil, RepMin: new(5), RepMax: new(10)},
-		}
-
-		p := prefs(time.Tuesday) // Requests 3 exercises.
-		wp := NewPlanner(p, exercises, nil)
-
-		// Request 3 exercises, but only 2 non-overlapping available.
-		// Expected: plan succeeds with 2 exercises, no error.
-		sets := wp.selectExercisesForDayWithPeriodization(
-			CategoryUpper,
-			[]string{"Chest", "Shoulders", "Triceps"},
-			3,
-			PeriodizationStrength,
-			false,
-			make(map[int]bool),
-		)
-
-		if len(sets) != 2 {
-			t.Errorf("want 2 exercises (graceful degradation), got %d", len(sets))
-		}
-
-		// Verify the 2 selected have no overlapping primary muscles.
-		seenPrimary := make(map[string]bool)
-		for _, es := range sets {
-			ex := findExercise(exercises, es.Exercise.ID)
+		seenPrimary := map[string]bool{}
+		for _, s := range slots {
+			ex := findExercise(exercises, s.Exercise.ID)
 			for _, mg := range ex.PrimaryMuscleGroups {
 				if seenPrimary[mg] {
-					t.Errorf("primary muscle group %q appears twice", mg)
+					t.Errorf("primary muscle group %q appears in two picks in the same session", mg)
 				}
 				seenPrimary[mg] = true
 			}
@@ -556,50 +345,150 @@ func TestSelectExercisesForDayGracefulDegradation(t *testing.T) {
 	})
 }
 
-func TestSelectExercisesForDay_TimeBasedTarget(t *testing.T) {
+func TestSelectExercises_WeekUsedExclusion(t *testing.T) {
 	t.Parallel()
 
-	starting := 30
-	plank := Exercise{ //nolint:exhaustruct // Test exercise omits unused display fields.
-		ID:                     21,
-		Category:               CategoryUpper,
-		ExerciseType:           ExerciseTypeTime,
-		PrimaryMuscleGroups:    []string{"Abs"},
-		SecondaryMuscleGroups:  nil,
-		DefaultStartingSeconds: &starting,
-		RepMin:                 nil,
-		RepMax:                 nil,
-	}
-
-	wp := &Planner{
-		Prefs: Preferences{ //nolint:exhaustruct // RestNotificationsEnabled irrelevant to planner tests.
-			Minutes: [7]int{time.Monday: 60},
+	exercises := []Exercise{
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
 		},
-		Exercises: []Exercise{plank},
-		Targets:   []MuscleGroupTarget{{MuscleGroupName: "Abs", WeeklySetTarget: 8}},
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
 	}
+	wp := NewPlanner(prefs(time.Tuesday), exercises, []MuscleGroupTarget{
+		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+		{MuscleGroupName: "Shoulders", WeeklySetTarget: 10},
+	})
+	load := map[string]float64{}
+	used := map[int]bool{1: true} // Exercise 1 was used earlier in the week.
 
-	sets := wp.selectExercisesForDayWithPeriodization(
-		CategoryUpper,
-		[]string{"Abs"},
-		1,
-		PeriodizationStrength,
-		false,
-		map[int]bool{},
+	slots := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper, 1, PeriodizationStrength, false, used, load,
 	)
+	if len(slots) != 1 {
+		t.Fatalf("want 1 slot, got %d", len(slots))
+	}
+	if slots[0].Exercise.ID == 1 {
+		t.Errorf("week-used exercise was picked anyway")
+	}
+}
 
-	if len(sets) != 1 {
-		t.Fatalf("got %d Slots, want 1", len(sets))
+func TestSelectExercises_TargetAwarePrefersUnderloadedMG(t *testing.T) {
+	t.Parallel()
+	// Pool has two equally-eligible exercises. Chest is at zero load,
+	// Shoulders already at target. The Chest exercise must win.
+	exercises := []Exercise{
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
 	}
-	if sets[0].Exercise.ID != plank.ID {
-		t.Fatalf("got exerciseID %d, want %d", sets[0].Exercise.ID, plank.ID)
+	wp := NewPlanner(prefs(time.Tuesday), exercises, []MuscleGroupTarget{
+		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+		{MuscleGroupName: "Shoulders", WeeklySetTarget: 10},
+	})
+	load := map[string]float64{"Shoulders": 10}
+	used := map[int]bool{}
+	slots := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper, 1, PeriodizationStrength, false, used, load,
+	)
+	if len(slots) != 1 {
+		t.Fatalf("want 1 slot, got %d", len(slots))
 	}
-	if len(sets[0].Sets) != defaultTimedSets {
-		t.Fatalf("got %d sets, want %d", len(sets[0].Sets), defaultTimedSets)
+	if slots[0].Exercise.ID != 2 {
+		t.Errorf("picked exercise %d (Shoulders); expected exercise 2 (Chest, under target)", slots[0].Exercise.ID)
 	}
-	for i, s := range sets[0].Sets {
+}
+
+func TestSelectExercises_FallsBackToLowestIDWhenScoresEqual(t *testing.T) {
+	t.Parallel()
+	// Empty targets: every candidate scores 0. Picker must return the
+	// lowest-id eligible candidate deterministically.
+	exercises := []Exercise{
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 7, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+	}
+	wp := NewPlanner(prefs(time.Tuesday), exercises, nil)
+	load := map[string]float64{}
+	used := map[int]bool{}
+	slots := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper, 1, PeriodizationStrength, false, used, load,
+	)
+	if len(slots) != 1 {
+		t.Fatalf("want 1 slot, got %d", len(slots))
+	}
+	if slots[0].Exercise.ID != 3 {
+		t.Errorf("got exercise %d; expected exercise 3 (lowest id among ties)", slots[0].Exercise.ID)
+	}
+}
+
+func TestSelectExercises_TimeBasedExerciseGetsThreeSets(t *testing.T) {
+	t.Parallel()
+	plank := Exercise{ //nolint:exhaustruct // Test exercises omit display fields.
+		ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeTime,
+		PrimaryMuscleGroups: []string{"Abs"}, SecondaryMuscleGroups: nil,
+		DefaultStartingSeconds: new(30),
+	}
+	wp := NewPlanner(prefs(time.Tuesday), []Exercise{plank}, []MuscleGroupTarget{
+		{MuscleGroupName: "Abs", WeeklySetTarget: 4},
+	})
+	load := map[string]float64{}
+	used := map[int]bool{}
+	slots := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper, 1, PeriodizationStrength, false, used, load,
+	)
+	if len(slots) != 1 {
+		t.Fatalf("want 1 slot, got %d", len(slots))
+	}
+	if len(slots[0].Sets) != defaultTimedSets {
+		t.Errorf("time-based slot has %d sets, want %d", len(slots[0].Sets), defaultTimedSets)
+	}
+	for _, s := range slots[0].Sets {
 		if s.TargetValue != 30 {
-			t.Errorf("set %d: TargetValue = %d, want 30 (DefaultStartingSeconds)", i, s.TargetValue)
+			t.Errorf("target seconds = %d, want 30", s.TargetValue)
+		}
+	}
+}
+
+func TestPlan_DoesNotRepeatExercisesAcrossDays(t *testing.T) {
+	t.Parallel()
+	exercises := minimalExercises()
+	targets := minimalTargets()
+	monday := monday2026Date()
+	p := prefs(time.Monday, time.Tuesday, time.Thursday)
+	wp := NewPlanner(p, exercises, targets)
+
+	plan, err := wp.Plan(monday)
+	if err != nil {
+		t.Fatalf("Plan failed: %v", err)
+	}
+
+	used := map[int]bool{}
+	for i := range plan.Sessions {
+		for _, slot := range plan.Sessions[i].Slots {
+			if used[slot.Exercise.ID] {
+				t.Errorf("exercise %d appears in two sessions across the week", slot.Exercise.ID)
+			}
+			used[slot.Exercise.ID] = true
 		}
 	}
 }

--- a/internal/domain/planner_internal_test.go
+++ b/internal/domain/planner_internal_test.go
@@ -186,60 +186,6 @@ func minimalTargets() []MuscleGroupTarget {
 	}
 }
 
-func TestAllocateMuscleGroups(t *testing.T) {
-	t.Parallel()
-
-	// Mon(Lower), Tue(Upper), Thu(Full Body) schedule.
-	monday := monday2026Date()
-	p := prefs(time.Monday, time.Tuesday, time.Thursday)
-	wp := NewPlanner(p, minimalExercises(), minimalTargets())
-
-	mon := monday          // Lower
-	tue := date(monday, 1) // Upper
-	thu := date(monday, 3) // Full Body
-
-	workoutDays := []time.Time{mon, tue, thu}
-	categories := map[time.Time]Category{
-		mon: CategoryLower,
-		tue: CategoryUpper,
-		thu: CategoryFullBody,
-	}
-
-	alloc := wp.allocateMuscleGroups(workoutDays, categories)
-
-	// Lower muscle groups (Quads, Hamstrings, Glutes) must appear on Mon (Lower
-	// compatible) and/or Thu (Full Body compatible), never on Tue (Upper only).
-	for _, mg := range []string{"Quads", "Hamstrings", "Glutes"} {
-		for _, assignedMG := range alloc[tue] {
-			if assignedMG == mg {
-				t.Errorf("lower muscle group %q must not be assigned to Upper day", mg)
-			}
-		}
-	}
-
-	// Upper muscle groups must not appear on Mon (Lower only).
-	for _, mg := range []string{"Chest", "Shoulders", "Triceps", "Biceps", "Upper Back", "Lats"} {
-		for _, assignedMG := range alloc[mon] {
-			if assignedMG == mg {
-				t.Errorf("upper muscle group %q must not be assigned to Lower day", mg)
-			}
-		}
-	}
-
-	// Every tracked muscle group must appear in at least 1 day's allocation.
-	allGroups := make(map[string]bool)
-	for _, groups := range alloc {
-		for _, g := range groups {
-			allGroups[g] = true
-		}
-	}
-	for _, target := range minimalTargets() {
-		if !allGroups[target.MuscleGroupName] {
-			t.Errorf("muscle group %q not assigned to any day", target.MuscleGroupName)
-		}
-	}
-}
-
 func TestSelectExercises_CategoryFilter(t *testing.T) {
 	t.Parallel()
 
@@ -1010,4 +956,219 @@ func Test_Plan_HypertrophyDaysGetExtraExerciseInMixedWeek(t *testing.T) {
 				i, sess.PeriodizationType, wantCount[i], got)
 		}
 	}
+}
+
+// prodLikePool returns a 15-exercise pool that mirrors the prod
+// secondary-footprint asymmetry: dense secondary coverage on Shoulders/
+// Upper Back/Triceps (so they could balloon under the old algorithm)
+// and sparse secondary coverage on Chest/Quads (so they could only
+// accumulate via primary picks).
+func prodLikePool() []Exercise {
+	return []Exercise{
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 1, Name: "Deadlift", Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes", "Hamstrings", "Lower Back"},
+			SecondaryMuscleGroups: []string{"Forearms", "Lats", "Quads", "Traps", "Upper Back"},
+			RepMin:                new(3), RepMax: new(6),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 2, Name: "Bench Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Chest", "Triceps"},
+			SecondaryMuscleGroups: []string{"Abs", "Forearms", "Shoulders"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 3, Name: "Tricep Pushdown", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Triceps"},
+			SecondaryMuscleGroups: []string{"Shoulders"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 4, Name: "Dumbbell Biceps Curl", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Biceps"},
+			SecondaryMuscleGroups: []string{"Forearms"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 5, Name: "Lateral Raise", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Shoulders"},
+			SecondaryMuscleGroups: []string{"Traps", "Upper Back"},
+			RepMin:                new(10), RepMax: new(20),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 6, Name: "Shoulder Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Shoulders"},
+			SecondaryMuscleGroups: []string{"Triceps", "Upper Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 7, Name: "Push-Up", Category: CategoryUpper, ExerciseType: ExerciseTypeBodyweight,
+			PrimaryMuscleGroups:   []string{"Chest", "Triceps"},
+			SecondaryMuscleGroups: []string{"Abs", "Forearms", "Shoulders", "Upper Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 8, Name: "Cable Fly", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Chest"},
+			SecondaryMuscleGroups: []string{"Shoulders", "Triceps"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 9, Name: "Pulldown", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Lats", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Biceps", "Shoulders"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 10, Name: "Face Pull", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Shoulders", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Traps", "Triceps"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 11, Name: "Leg Press", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
+			SecondaryMuscleGroups: []string{"Calves", "Hamstrings"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 12, Name: "Leg Extension", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Quads"},
+			SecondaryMuscleGroups: []string{"Hip Flexors"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 13, Name: "Squat", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
+			SecondaryMuscleGroups: []string{"Hamstrings", "Lower Back"},
+			RepMin:                new(3), RepMax: new(6),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 14, Name: "Leg Curl", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Hamstrings"},
+			SecondaryMuscleGroups: []string{"Calves"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 15, Name: "Romanian Deadlift", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes", "Hamstrings"},
+			SecondaryMuscleGroups: []string{"Lower Back"},
+			RepMin:                new(8), RepMax: new(20),
+		},
+	}
+}
+
+func prodLikeTargets() []MuscleGroupTarget {
+	return []MuscleGroupTarget{
+		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+		{MuscleGroupName: "Shoulders", WeeklySetTarget: 10},
+		{MuscleGroupName: "Triceps", WeeklySetTarget: 8},
+		{MuscleGroupName: "Biceps", WeeklySetTarget: 8},
+		{MuscleGroupName: "Upper Back", WeeklySetTarget: 10},
+		{MuscleGroupName: "Lats", WeeklySetTarget: 10},
+		{MuscleGroupName: "Quads", WeeklySetTarget: 10},
+		{MuscleGroupName: "Hamstrings", WeeklySetTarget: 8},
+		{MuscleGroupName: "Glutes", WeeklySetTarget: 8},
+	}
+}
+
+// prefs90 returns prefs with the given weekdays scheduled at 90 minutes
+// (the size that triggers exercisesLong / exercisesLongHypertrophy).
+func prefs90(days ...time.Weekday) Preferences {
+	p := Preferences{} //nolint:exhaustruct // Other prefs irrelevant to this test.
+	for _, d := range days {
+		p.Minutes[d] = 90
+	}
+	return p
+}
+
+func TestPlan_TargetAwareBalanceUnderProdLikePool(t *testing.T) {
+	t.Parallel()
+	// Tue/Thu/Sat 90 min, all FullBody. This is user 24's current schedule;
+	// under the old algorithm Shoulders/Triceps/Upper Back ballooned and
+	// Chest/Quads sat under target.
+	p := prefs90(time.Tuesday, time.Thursday, time.Saturday)
+	wp := NewPlanner(p, prodLikePool(), prodLikeTargets())
+
+	plan, err := wp.Plan(monday2026Date())
+	if err != nil {
+		t.Fatalf("Plan failed: %v", err)
+	}
+
+	load := WeeklyPlannedLoad(planSessions(plan))
+	for _, target := range prodLikeTargets() {
+		l := load[target.MuscleGroupName]
+		t.Logf("%s planned %.1f / target %d", target.MuscleGroupName, l, target.WeeklySetTarget)
+	}
+
+	// 1.85x cap rather than the spec's 1.5x: on this synthetic 15-exercise
+	// pool the dense secondary footprint on Shoulders/Triceps forces them to
+	// 1.6x / 1.81x even after the rewrite (down from 1.75x / 1.81x under
+	// the old algorithm). Real prod has 38 exercises with more escape
+	// routes; the 1.85x bound here catches major regressions without
+	// constraining the synthetic worst case.
+	for _, target := range prodLikeTargets() {
+		l := load[target.MuscleGroupName]
+		upper := 1.85 * float64(target.WeeklySetTarget)
+		if l > upper {
+			t.Errorf("%s planned %.1f exceeds 1.85x target (%v)", target.MuscleGroupName, l, upper)
+		}
+	}
+	if got := load["Chest"]; got < 8 {
+		t.Errorf("Chest planned %.1f is below the prior under-load floor (8.0)", got)
+	}
+}
+
+func planSessions(plan WeekPlan) []Session {
+	var ss []Session
+	for i := range plan.Sessions {
+		if len(plan.Sessions[i].Slots) > 0 {
+			ss = append(ss, plan.Sessions[i])
+		}
+	}
+	return ss
+}
+
+func TestPlan_DeterministicAcrossRuns(t *testing.T) {
+	t.Parallel()
+	// Same inputs twice → byte-equal Sessions output. Guards against map
+	// iteration order leaking into selection.
+	p := prefs90(time.Tuesday, time.Thursday, time.Saturday)
+	wp := NewPlanner(p, prodLikePool(), prodLikeTargets())
+
+	monday := monday2026Date()
+	planA, err := wp.Plan(monday)
+	if err != nil {
+		t.Fatalf("Plan A failed: %v", err)
+	}
+	planB, err := wp.Plan(monday)
+	if err != nil {
+		t.Fatalf("Plan B failed: %v", err)
+	}
+
+	for i := range 7 {
+		if got, want := slotIDs(planA.Sessions[i]), slotIDs(planB.Sessions[i]); !sliceEqInt(got, want) {
+			t.Errorf("day %d differs: A=%v B=%v", i, got, want)
+		}
+	}
+}
+
+func slotIDs(s Session) []int {
+	ids := make([]int, len(s.Slots))
+	for i, slot := range s.Slots {
+		ids[i] = slot.Exercise.ID
+	}
+	return ids
+}
+
+func sliceEqInt(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/domain/planner_internal_test.go
+++ b/internal/domain/planner_internal_test.go
@@ -415,6 +415,74 @@ func TestSelectExercises_TimeBasedExerciseGetsThreeSets(t *testing.T) {
 	}
 }
 
+func TestSelectExercises_WeightedExerciseSetCountMatchesDeriveScheme(t *testing.T) {
+	t.Parallel()
+	// A weighted exercise picked via selectExercisesForDayWithPeriodization
+	// should carry the set count and per-set target reps that
+	// DeriveScheme produces for the same exercise + periodization.
+	bench := Exercise{ //nolint:exhaustruct // Test exercise omits display fields.
+		ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+		PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+		RepMin: new(5), RepMax: new(10),
+	}
+	wp := NewPlanner(prefs(time.Tuesday), []Exercise{bench}, []MuscleGroupTarget{
+		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+	})
+	load := map[string]float64{}
+	used := map[int]bool{}
+	slots := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper, 1, PeriodizationStrength, false, used, load,
+	)
+	if len(slots) != 1 {
+		t.Fatalf("want 1 slot, got %d", len(slots))
+	}
+	wantReps, wantSets := deriveSchemeForExercise(bench, PeriodizationStrength, false)
+	if len(slots[0].Sets) != wantSets {
+		t.Errorf("set count = %d, want %d", len(slots[0].Sets), wantSets)
+	}
+	for i, s := range slots[0].Sets {
+		if s.TargetValue != wantReps {
+			t.Errorf("set %d target reps = %d, want %d", i, s.TargetValue, wantReps)
+		}
+	}
+}
+
+func TestSelectExercises_GracefulDegradationWhenAllSharePrimaryMG(t *testing.T) {
+	t.Parallel()
+	// Pool: three exercises all primary on Chest. The session asks for 3
+	// slots but only the first pick can satisfy the no-primary-overlap
+	// rule; the loop must stop early and return one slot (graceful
+	// degradation), not loop forever or panic.
+	exercises := []Exercise{
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercises omit display fields.
+			ID: 3, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+	}
+	wp := NewPlanner(prefs(time.Tuesday), exercises, []MuscleGroupTarget{
+		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+	})
+	load := map[string]float64{}
+	used := map[int]bool{}
+	slots := wp.selectExercisesForDayWithPeriodization(
+		CategoryUpper, 3, PeriodizationStrength, false, used, load,
+	)
+	if len(slots) != 1 {
+		t.Errorf("want 1 slot (graceful degradation under primary-overlap exhaustion), got %d", len(slots))
+	}
+}
+
 func TestPlan_DoesNotRepeatExercisesAcrossDays(t *testing.T) {
 	t.Parallel()
 	exercises := minimalExercises()
@@ -958,12 +1026,13 @@ func Test_Plan_HypertrophyDaysGetExtraExerciseInMixedWeek(t *testing.T) {
 	}
 }
 
-// prodLikePool returns a 15-exercise pool that mirrors the prod
-// secondary-footprint asymmetry: dense secondary coverage on Shoulders/
-// Upper Back/Triceps (so they could balloon under the old algorithm)
-// and sparse secondary coverage on Chest/Quads (so they could only
-// accumulate via primary picks).
-func prodLikePool() []Exercise {
+// seedExercises mirrors the 39 exercises in internal/sqlite/fixtures.sql
+// verbatim (IDs, categories, types, rep windows, and primary/secondary
+// muscle groups all match). It keeps the regression test pure-domain while
+// exercising the algorithm against the actual seed users start with.
+// Update both this helper and fixtures.sql together when seed exercises
+// change.
+func seedExercises() []Exercise {
 	return []Exercise{
 		{ //nolint:exhaustruct // Test exercise omits display fields.
 			ID: 1, Name: "Deadlift", Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
@@ -996,15 +1065,15 @@ func prodLikePool() []Exercise {
 			RepMin:                new(10), RepMax: new(20),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 6, Name: "Shoulder Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			ID: 6, Name: "Dumbbell Shoulder Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups:   []string{"Shoulders"},
 			SecondaryMuscleGroups: []string{"Triceps", "Upper Back"},
 			RepMin:                new(5), RepMax: new(10),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 7, Name: "Push-Up", Category: CategoryUpper, ExerciseType: ExerciseTypeBodyweight,
-			PrimaryMuscleGroups:   []string{"Chest", "Triceps"},
-			SecondaryMuscleGroups: []string{"Abs", "Forearms", "Shoulders", "Upper Back"},
+			ID: 7, Name: "Dumbbell Bench Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Chest"},
+			SecondaryMuscleGroups: []string{"Shoulders", "Triceps"},
 			RepMin:                new(5), RepMax: new(10),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
@@ -1020,45 +1089,189 @@ func prodLikePool() []Exercise {
 			RepMin:                new(5), RepMax: new(10),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 10, Name: "Face Pull", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups:   []string{"Shoulders", "Upper Back"},
-			SecondaryMuscleGroups: []string{"Traps", "Triceps"},
+			ID: 10, Name: "Pulldown, Reverse Grip", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Biceps", "Lats"},
+			SecondaryMuscleGroups: []string{"Forearms", "Upper Back"},
 			RepMin:                new(5), RepMax: new(10),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 11, Name: "Leg Press", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			ID: 11, Name: "Seated Cable Row", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Lats", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Biceps", "Lower Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 12, Name: "One-Arm Dumbbell Row", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Lats", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Biceps", "Forearms"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 13, Name: "Abdominal Machine Crunch", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Abs"},
+			SecondaryMuscleGroups: []string{"Obliques"},
+			RepMin:                new(8), RepMax: new(15),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 14, Name: "Leg Press", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
 			SecondaryMuscleGroups: []string{"Calves", "Hamstrings"},
 			RepMin:                new(5), RepMax: new(10),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 12, Name: "Leg Extension", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			ID: 15, Name: "Leg Extension", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups:   []string{"Quads"},
 			SecondaryMuscleGroups: []string{"Hip Flexors"},
 			RepMin:                new(8), RepMax: new(12),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 13, Name: "Squat", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
-			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
-			SecondaryMuscleGroups: []string{"Hamstrings", "Lower Back"},
-			RepMin:                new(3), RepMax: new(6),
-		},
-		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 14, Name: "Leg Curl", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			ID: 16, Name: "Leg Curl", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups:   []string{"Hamstrings"},
 			SecondaryMuscleGroups: []string{"Calves"},
 			RepMin:                new(8), RepMax: new(12),
 		},
 		{ //nolint:exhaustruct // Test exercise omits display fields.
-			ID: 15, Name: "Romanian Deadlift", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			ID: 17, Name: "Calf Raise", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Calves"},
+			SecondaryMuscleGroups: []string{"Quads"},
+			RepMin:                new(10), RepMax: new(20),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 18, Name: "Back Extension", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Lower Back"},
+			SecondaryMuscleGroups: []string{"Glutes", "Hamstrings"},
+			RepMin:                new(8), RepMax: new(20),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 19, Name: "Push-Up", Category: CategoryUpper, ExerciseType: ExerciseTypeBodyweight,
+			PrimaryMuscleGroups:   []string{"Chest", "Triceps"},
+			SecondaryMuscleGroups: []string{"Abs", "Forearms", "Shoulders", "Upper Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 20, Name: "Ab Wheel Rollout", Category: CategoryUpper, ExerciseType: ExerciseTypeBodyweight,
+			PrimaryMuscleGroups:   []string{"Abs", "Obliques"},
+			SecondaryMuscleGroups: []string{"Calves", "Glutes", "Hamstrings", "Lats", "Quads", "Shoulders"},
+			RepMin:                new(8), RepMax: new(15),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 21, Name: "Plank", Category: CategoryUpper, ExerciseType: ExerciseTypeBodyweight,
+			PrimaryMuscleGroups:   []string{"Abs"},
+			SecondaryMuscleGroups: []string{"Glutes", "Hip Flexors", "Lower Back", "Obliques", "Quads", "Shoulders"},
+			RepMin:                new(8), RepMax: new(15),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 22, Name: "Incline Dumbbell Bench Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Chest"},
+			SecondaryMuscleGroups: []string{"Shoulders", "Triceps", "Upper Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 23, Name: "Romanian Deadlift", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups:   []string{"Glutes", "Hamstrings"},
 			SecondaryMuscleGroups: []string{"Lower Back"},
 			RepMin:                new(8), RepMax: new(20),
 		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 24, Name: "Assisted Pull-Up", Category: CategoryUpper, ExerciseType: ExerciseTypeAssisted,
+			PrimaryMuscleGroups:   []string{"Lats", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Biceps", "Forearms"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 25, Name: "Hip Abductor", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes"},
+			SecondaryMuscleGroups: nil,
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 26, Name: "Hip Adductor", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Adductors"},
+			SecondaryMuscleGroups: []string{"Glutes"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 27, Name: "Rotary Torso", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Obliques"},
+			SecondaryMuscleGroups: []string{"Abs"},
+			RepMin:                new(8), RepMax: new(15),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 28, Name: "Seated Calf Raise", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Calves"},
+			SecondaryMuscleGroups: nil,
+			RepMin:                new(10), RepMax: new(20),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 29, Name: "Squat", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
+			SecondaryMuscleGroups: []string{"Hamstrings", "Lower Back"},
+			RepMin:                new(3), RepMax: new(6),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 30, Name: "Pec Fly", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Chest"},
+			SecondaryMuscleGroups: []string{"Shoulders"},
+			RepMin:                new(8), RepMax: new(12),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 31, Name: "Smith Machine Squat", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
+			SecondaryMuscleGroups: []string{"Abs", "Hamstrings"},
+			RepMin:                new(3), RepMax: new(6),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 32, Name: "Overhead Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Shoulders", "Triceps"},
+			SecondaryMuscleGroups: []string{"Abs", "Upper Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 33, Name: "Barbell Row", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Lats", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Biceps", "Lower Back"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 34, Name: "Face Pull", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Shoulders", "Upper Back"},
+			SecondaryMuscleGroups: []string{"Traps", "Triceps"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 35, Name: "Hip Thrust", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Glutes"},
+			SecondaryMuscleGroups: []string{"Hamstrings", "Quads"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 36, Name: "Bulgarian Split Squat", Category: CategoryLower, ExerciseType: ExerciseTypeBodyweight,
+			PrimaryMuscleGroups:   []string{"Glutes", "Quads"},
+			SecondaryMuscleGroups: []string{"Abs", "Hamstrings"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 37, Name: "Hammer Curl", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Biceps", "Forearms"},
+			SecondaryMuscleGroups: []string{"Shoulders", "Triceps"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 38, Name: "Skull Crusher", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Triceps"},
+			SecondaryMuscleGroups: []string{"Forearms", "Shoulders"},
+			RepMin:                new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 39, Name: "Hanging Leg Raise", Category: CategoryUpper, ExerciseType: ExerciseTypeBodyweight,
+			PrimaryMuscleGroups:   []string{"Abs", "Hip Flexors"},
+			SecondaryMuscleGroups: []string{"Forearms", "Obliques"},
+			RepMin:                new(5), RepMax: new(10),
+		},
 	}
 }
 
-func prodLikeTargets() []MuscleGroupTarget {
+func seedTargets() []MuscleGroupTarget {
 	return []MuscleGroupTarget{
 		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
 		{MuscleGroupName: "Shoulders", WeeklySetTarget: 10},
@@ -1082,13 +1295,13 @@ func prefs90(days ...time.Weekday) Preferences {
 	return p
 }
 
-func TestPlan_TargetAwareBalanceUnderProdLikePool(t *testing.T) {
+func TestPlan_TargetAwareBalanceUnderSeedExercises(t *testing.T) {
 	t.Parallel()
 	// Tue/Thu/Sat 90 min, all FullBody. This is user 24's current schedule;
 	// under the old algorithm Shoulders/Triceps/Upper Back ballooned and
 	// Chest/Quads sat under target.
 	p := prefs90(time.Tuesday, time.Thursday, time.Saturday)
-	wp := NewPlanner(p, prodLikePool(), prodLikeTargets())
+	wp := NewPlanner(p, seedExercises(), seedTargets())
 
 	plan, err := wp.Plan(monday2026Date())
 	if err != nil {
@@ -1096,22 +1309,28 @@ func TestPlan_TargetAwareBalanceUnderProdLikePool(t *testing.T) {
 	}
 
 	load := WeeklyPlannedLoad(planSessions(plan))
-	for _, target := range prodLikeTargets() {
+	for _, target := range seedTargets() {
 		l := load[target.MuscleGroupName]
 		t.Logf("%s planned %.1f / target %d", target.MuscleGroupName, l, target.WeeklySetTarget)
 	}
 
-	// 1.85x cap rather than the spec's 1.5x: on this synthetic 15-exercise
-	// pool the dense secondary footprint on Shoulders/Triceps forces them to
-	// 1.6x / 1.81x even after the rewrite (down from 1.75x / 1.81x under
-	// the old algorithm). Real prod has 38 exercises with more escape
-	// routes; the 1.85x bound here catches major regressions without
-	// constraining the synthetic worst case.
-	for _, target := range prodLikeTargets() {
+	// Spec bounds: every targeted MG within [0.7x, 1.4x] of target, and
+	// no MG exceeds 1.5x (a hard ceiling). Chest >= 8 sets is the
+	// regression floor — under the old algorithm Chest sat at 8.0 (-20%)
+	// while Shoulders/Triceps/Upper Back ballooned to 1.65-1.81x.
+	for _, target := range seedTargets() {
 		l := load[target.MuscleGroupName]
-		upper := 1.85 * float64(target.WeeklySetTarget)
+		lower := 0.7 * float64(target.WeeklySetTarget)
+		upper := 1.4 * float64(target.WeeklySetTarget)
+		hardCeiling := 1.5 * float64(target.WeeklySetTarget)
+		if l < lower {
+			t.Errorf("%s planned %.1f is below 0.7x target (%v)", target.MuscleGroupName, l, lower)
+		}
 		if l > upper {
-			t.Errorf("%s planned %.1f exceeds 1.85x target (%v)", target.MuscleGroupName, l, upper)
+			t.Errorf("%s planned %.1f exceeds 1.4x target (%v)", target.MuscleGroupName, l, upper)
+		}
+		if l > hardCeiling {
+			t.Errorf("%s planned %.1f exceeds 1.5x hard ceiling (%v)", target.MuscleGroupName, l, hardCeiling)
 		}
 	}
 	if got := load["Chest"]; got < 8 {
@@ -1134,7 +1353,7 @@ func TestPlan_DeterministicAcrossRuns(t *testing.T) {
 	// Same inputs twice → byte-equal Sessions output. Guards against map
 	// iteration order leaking into selection.
 	p := prefs90(time.Tuesday, time.Thursday, time.Saturday)
-	wp := NewPlanner(p, prodLikePool(), prodLikeTargets())
+	wp := NewPlanner(p, seedExercises(), seedTargets())
 
 	monday := monday2026Date()
 	planA, err := wp.Plan(monday)

--- a/internal/domain/planner_internal_test.go
+++ b/internal/domain/planner_internal_test.go
@@ -996,6 +996,82 @@ func Test_exercisesPerSession_PeriodizationAware(t *testing.T) {
 	}
 }
 
+func Test_scoreCandidate(t *testing.T) {
+	t.Parallel()
+
+	bench := Exercise{ //nolint:exhaustruct // Test exercise omits display fields.
+		ID:                    1,
+		Category:              CategoryUpper,
+		ExerciseType:          ExerciseTypeWeighted,
+		PrimaryMuscleGroups:   []string{"Chest", "Triceps"},
+		SecondaryMuscleGroups: []string{"Shoulders"},
+		RepMin:                new(5), RepMax: new(10),
+	}
+
+	targets := map[string]int{"Chest": 10, "Triceps": 8, "Shoulders": 10}
+
+	t.Run("positive when pulling under-target MGs up", func(t *testing.T) {
+		t.Parallel()
+		// Empty load: every targeted MG at full deficit.
+		load := map[string]float64{}
+		// Strength + 5-10 window: reps=5, sets=4 (DeriveScheme low band).
+		score := scoreCandidate(bench, PeriodizationStrength, false, load, targets)
+		// Chest: before=10, after=10-4=6; contribution 100-36=64.
+		// Triceps: before=8, after=8-4=4; contribution 64-16=48.
+		// Shoulders: before=10, after=10-2=8; contribution 100-64=36.
+		// Total = 64 + 48 + 36 = 148.
+		if score != 148 {
+			t.Errorf("score = %v, want 148", score)
+		}
+	})
+
+	t.Run("negative when pushing on-target MG further over", func(t *testing.T) {
+		t.Parallel()
+		// Shoulders already at 12 (2 over target 10); other MGs at target.
+		load := map[string]float64{"Chest": 10, "Triceps": 8, "Shoulders": 12}
+		score := scoreCandidate(bench, PeriodizationStrength, false, load, targets)
+		// Chest: before=0, after=-4; 0-16=-16.
+		// Triceps: before=0, after=-4; 0-16=-16.
+		// Shoulders: before=-2, after=-4; 4-16=-12.
+		// Total = -16 + -16 + -12 = -44.
+		if score != -44 {
+			t.Errorf("score = %v, want -44", score)
+		}
+	})
+
+	t.Run("zero when no targeted MG is touched", func(t *testing.T) {
+		t.Parallel()
+		calfRaise := Exercise{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID:                    99,
+			Category:              CategoryLower,
+			ExerciseType:          ExerciseTypeWeighted,
+			PrimaryMuscleGroups:   []string{"Calves"},
+			SecondaryMuscleGroups: nil,
+			RepMin:                new(10), RepMax: new(20),
+		}
+		load := map[string]float64{}
+		score := scoreCandidate(calfRaise, PeriodizationStrength, false, load, targets)
+		if score != 0 {
+			t.Errorf("score = %v, want 0", score)
+		}
+	})
+
+	t.Run("deload halves set count", func(t *testing.T) {
+		t.Parallel()
+		load := map[string]float64{}
+		// Strength + deload + 5-10 window: reps=10 (deload forces hypertrophy),
+		// base sets = 3 (mid band, 6 <= reps <= 10), halved to 2.
+		score := scoreCandidate(bench, PeriodizationStrength, true, load, targets)
+		// Chest: 100 - (10-2)^2 = 100 - 64 = 36.
+		// Triceps: 64 - (8-2)^2 = 64 - 36 = 28.
+		// Shoulders: 100 - (10-1)^2 = 100 - 81 = 19.
+		// Total = 36 + 28 + 19 = 83.
+		if score != 83 {
+			t.Errorf("score = %v, want 83", score)
+		}
+	})
+}
+
 func Test_Plan_HypertrophyDaysGetExtraExerciseInMixedWeek(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/planner_plan_day_internal_test.go
+++ b/internal/domain/planner_plan_day_internal_test.go
@@ -8,33 +8,34 @@ import (
 
 // planDayExercises returns a small pool with Upper, Lower, and FullBody coverage
 // across distinct primary muscles so PlanDay's non-conflict selection has room.
-// FullBody is listed first so FullBody-day selection (greedy first-pick) includes it,
-// making sess.WorkoutType() return CategoryFullBody reliably in tests.
+// The FullBody Plank carries the lowest ID so the lowest-id tie-break picks it
+// first on FullBody days with empty targets, making sess.WorkoutType() return
+// CategoryFullBody reliably in tests.
 func planDayExercises() []Exercise {
 	intPtr := func(v int) *int { return &v }
 	return []Exercise{
 		{ //nolint:exhaustruct // Test exercises omit unused display fields.
-			ID: 6, Name: "Plank", Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
+			ID: 1, Name: "Plank", Category: CategoryFullBody, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups: []string{"Core"}, SecondaryMuscleGroups: nil,
 			RepMin: intPtr(5), RepMax: intPtr(10)},
 		{ //nolint:exhaustruct // Test exercises omit unused display fields.
-			ID: 1, Name: "Bench Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			ID: 2, Name: "Bench Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: []string{"Triceps"},
 			RepMin: intPtr(5), RepMax: intPtr(10)},
 		{ //nolint:exhaustruct // Test exercises omit unused display fields.
-			ID: 2, Name: "Row", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			ID: 3, Name: "Row", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups: []string{"Upper Back"}, SecondaryMuscleGroups: []string{"Biceps"},
 			RepMin: intPtr(5), RepMax: intPtr(10)},
 		{ //nolint:exhaustruct // Test exercises omit unused display fields.
-			ID: 3, Name: "Overhead Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			ID: 4, Name: "Overhead Press", Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: []string{"Triceps"},
 			RepMin: intPtr(5), RepMax: intPtr(10)},
 		{ //nolint:exhaustruct // Test exercises omit unused display fields.
-			ID: 4, Name: "Squat", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			ID: 5, Name: "Squat", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups: []string{"Quads"}, SecondaryMuscleGroups: []string{"Glutes"},
 			RepMin: intPtr(5), RepMax: intPtr(10)},
 		{ //nolint:exhaustruct // Test exercises omit unused display fields.
-			ID: 5, Name: "Deadlift", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
+			ID: 6, Name: "Deadlift", Category: CategoryLower, ExerciseType: ExerciseTypeWeighted,
 			PrimaryMuscleGroups: []string{"Hamstrings"}, SecondaryMuscleGroups: []string{"Glutes"},
 			RepMin: intPtr(5), RepMax: intPtr(10)},
 	}
@@ -117,18 +118,24 @@ func TestPlanner_PlanDay_AvoidsUsedExercises(t *testing.T) {
 	t.Parallel()
 
 	// Force the upper-only pool by picking Tue with Mon and Wed scheduled.
-	// Then mark exercises 1,2 as used; only id 3 (Overhead Press) remains.
+	// Mark exercises 1,2 as used; the planner must not return them. The
+	// selector mutates the supplied used-set with the IDs it picks, so we
+	// snapshot the pre-call IDs before checking.
 	p := prefs(time.Monday, time.Wednesday)
 	wp := newPlanDayPlanner(t, p)
 	tue := date(monday2026Date(), 1) // unscheduled Tuesday between two on days
 	used := map[int]bool{1: true, 2: true}
+	preUsed := map[int]bool{}
+	for id := range used {
+		preUsed[id] = true
+	}
 
 	sess, err := wp.PlanDay(tue, used)
 	if err != nil {
 		t.Fatalf("PlanDay: %v", err)
 	}
 	for _, es := range sess.Slots {
-		if used[es.Exercise.ID] {
+		if preUsed[es.Exercise.ID] {
 			t.Errorf("PlanDay returned used exercise id=%d", es.Exercise.ID)
 		}
 	}

--- a/internal/domain/planner_plan_day_internal_test.go
+++ b/internal/domain/planner_plan_day_internal_test.go
@@ -53,7 +53,7 @@ func TestPlanner_PlanDay_IsolatedDateDefaultsToFullBody(t *testing.T) {
 	wp := newPlanDayPlanner(t, Preferences{}) //nolint:exhaustruct // all zero on purpose.
 	wed := date(monday2026Date(), 2)
 
-	sess, err := wp.PlanDay(wed, nil)
+	sess, err := wp.PlanDay(wed, nil, nil)
 	if err != nil {
 		t.Fatalf("PlanDay: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestPlanner_PlanDay_AdjacencyToScheduledTomorrowPicksLower(t *testing.T) {
 	wp := newPlanDayPlanner(t, prefs(time.Tuesday))
 	mon := monday2026Date()
 
-	sess, err := wp.PlanDay(mon, nil)
+	sess, err := wp.PlanDay(mon, nil, nil)
 	if err != nil {
 		t.Fatalf("PlanDay: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestPlanner_PlanDay_PeriodizationMatchesWeeklyPlannerForScheduledDate(t *te
 			continue
 		}
 		var got Session
-		got, err = wp.PlanDay(want.Date, nil)
+		got, err = wp.PlanDay(want.Date, nil, nil)
 		if err != nil {
 			t.Fatalf("PlanDay(%s): %v", want.Date.Weekday(), err)
 		}
@@ -130,7 +130,7 @@ func TestPlanner_PlanDay_AvoidsUsedExercises(t *testing.T) {
 		preUsed[id] = true
 	}
 
-	sess, err := wp.PlanDay(tue, used)
+	sess, err := wp.PlanDay(tue, used, nil)
 	if err != nil {
 		t.Fatalf("PlanDay: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestPlanner_PlanDay_UsesPrefsExerciseCountWhenScheduled(t *testing.T) {
 	wp := newPlanDayPlanner(t, p)
 	wed := date(monday2026Date(), 2)
 
-	sess, err := wp.PlanDay(wed, nil)
+	sess, err := wp.PlanDay(wed, nil, nil)
 	if err != nil {
 		t.Fatalf("PlanDay: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestPlanner_PlanDay_EmptyCategoryPoolReturnsError(t *testing.T) {
 	wp := NewPlanner(prefs(time.Monday, time.Tuesday), noLower, nil)
 	mon := monday2026Date()
 
-	_, err := wp.PlanDay(mon, nil)
+	_, err := wp.PlanDay(mon, nil, nil)
 	if err == nil {
 		t.Fatal("PlanDay must error when category pool is empty")
 	}
@@ -207,12 +207,49 @@ func TestPlanner_PlanDay_PeriodizationMatchesWeeklyPlannerForSundaySchedule(t *t
 		}
 	}
 
-	got, err := wp.PlanDay(sun, nil)
+	got, err := wp.PlanDay(sun, nil, nil)
 	if err != nil {
 		t.Fatalf("PlanDay(Sunday): %v", err)
 	}
 	if got.PeriodizationType != planSunPT {
 		t.Errorf("Sunday PeriodizationType = %s, want %s (matches weekly planner)",
 			got.PeriodizationType, planSunPT)
+	}
+}
+
+func TestPlanner_PlanDay_AvoidsAlreadyLoadedMuscleGroup(t *testing.T) {
+	t.Parallel()
+	// Pool: one Shoulders-primary exercise, one Chest-primary exercise.
+	exercises := []Exercise{
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 1, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Shoulders"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+		{ //nolint:exhaustruct // Test exercise omits display fields.
+			ID: 2, Category: CategoryUpper, ExerciseType: ExerciseTypeWeighted,
+			PrimaryMuscleGroups: []string{"Chest"}, SecondaryMuscleGroups: nil,
+			RepMin: new(5), RepMax: new(10),
+		},
+	}
+	targets := []MuscleGroupTarget{
+		{MuscleGroupName: "Shoulders", WeeklySetTarget: 10},
+		{MuscleGroupName: "Chest", WeeklySetTarget: 10},
+	}
+	// Tuesday scheduled so category=FullBody (isolated day).
+	p := Preferences{} //nolint:exhaustruct // Other prefs irrelevant.
+	p.Minutes[time.Tuesday] = 60
+	wp := NewPlanner(p, exercises, targets)
+
+	weekLoad := map[string]float64{"Shoulders": 10} // Already at target.
+	sess, err := wp.PlanDay(time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC), nil, weekLoad)
+	if err != nil {
+		t.Fatalf("PlanDay: %v", err)
+	}
+	if len(sess.Slots) == 0 {
+		t.Fatalf("no slots picked")
+	}
+	if sess.Slots[0].Exercise.ID != 2 {
+		t.Errorf("first pick is exercise %d; expected exercise 2 (Chest, under target)", sess.Slots[0].Exercise.ID)
 	}
 }

--- a/internal/service/sessions.go
+++ b/internal/service/sessions.go
@@ -145,9 +145,12 @@ func usedExerciseIDs(plan domain.WeekPlan) map[int]bool {
 
 // planSingleDay builds a Session for date via the Planner, seeding deload
 // weights if needed. Pure in-memory; no DB writes. Returns the session ready
-// to be placed into a WeekPlan at the right offset.
+// to be placed into a WeekPlan at the right offset. The supplied plan is
+// the current week's persisted state: planSingleDay derives the no-repeat
+// used-set and the per-MG weighted-load seed from it so PlanDay's
+// target-aware selection sees what the rest of the week already covers.
 func (s *Service) planSingleDay(
-	ctx context.Context, date time.Time, used map[int]bool,
+	ctx context.Context, date time.Time, plan domain.WeekPlan,
 ) (domain.Session, error) {
 	prefs, err := s.repos.Preferences.Get(ctx)
 	if err != nil {
@@ -161,8 +164,16 @@ func (s *Service) planSingleDay(
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("get muscle group targets: %w", err)
 	}
+	used := usedExerciseIDs(plan)
+	var sessions []domain.Session
+	for i := range plan.Sessions {
+		if len(plan.Sessions[i].Slots) > 0 {
+			sessions = append(sessions, plan.Sessions[i])
+		}
+	}
+	weekLoad := domain.WeeklyPlannedLoad(sessions)
 	planner := domain.NewPlanner(prefs, exercises, targets)
-	sess, err := planner.PlanDay(date, used, nil)
+	sess, err := planner.PlanDay(date, used, weekLoad)
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("plan day %s: %w", date.Format(time.DateOnly), err)
 	}
@@ -177,9 +188,9 @@ func (s *Service) planSingleDay(
 // createAdHocSession plans and persists a single session for date via the
 // WeekPlanRepository.Update closure. Used by StartSession when the user
 // starts an unscheduled day (extra workout) or a day added to the schedule
-// mid-week after another in-week session was already started. used is the
-// set of exercise IDs already used in other in-week sessions, passed
-// through to PlanDay's no-repeat selection.
+// mid-week after another in-week session was already started. plan is the
+// current week's persisted state; planSingleDay derives both the no-repeat
+// used-set and the per-MG weighted-load seed from it.
 //
 // The closure overwrites the rest-day placeholder at the right offset; the
 // single-pass reinsert in WeekPlanRepository.Update writes each slot's
@@ -187,8 +198,8 @@ func (s *Service) planSingleDay(
 // sessions' slot positions survive untouched.
 // Callers must ensure the week row exists first (StartSession does so via
 // WeekPlans.Create) — Update returns domain.ErrNotFound otherwise.
-func (s *Service) createAdHocSession(ctx context.Context, date time.Time, used map[int]bool) error {
-	sess, err := s.planSingleDay(ctx, date, used)
+func (s *Service) createAdHocSession(ctx context.Context, date time.Time, plan domain.WeekPlan) error {
+	sess, err := s.planSingleDay(ctx, date, plan)
 	if err != nil {
 		return err
 	}
@@ -241,8 +252,7 @@ func (s *Service) StartSession(ctx context.Context, date time.Time) error {
 	sessOnDate := plan.SessionOn(date)
 	hasDate := sessOnDate != nil && len(sessOnDate.Slots) > 0
 	if !hasDate {
-		used := usedExerciseIDs(plan)
-		if err = s.createAdHocSession(ctx, date, used); err != nil && !errors.Is(err, domain.ErrAlreadyExists) {
+		if err = s.createAdHocSession(ctx, date, plan); err != nil && !errors.Is(err, domain.ErrAlreadyExists) {
 			return fmt.Errorf("create ad-hoc %s: %w", date.Format(time.DateOnly), err)
 		}
 	}

--- a/internal/service/sessions.go
+++ b/internal/service/sessions.go
@@ -162,7 +162,7 @@ func (s *Service) planSingleDay(
 		return domain.Session{}, fmt.Errorf("get muscle group targets: %w", err)
 	}
 	planner := domain.NewPlanner(prefs, exercises, targets)
-	sess, err := planner.PlanDay(date, used)
+	sess, err := planner.PlanDay(date, used, nil)
 	if err != nil {
 		return domain.Session{}, fmt.Errorf("plan day %s: %w", date.Format(time.DateOnly), err)
 	}


### PR DESCRIPTION
## Summary

- Replace the priority-MG allocation + two-phase exercise selection in `internal/domain/planner.go` with a single target-aware greedy scoring loop that minimises the sum of squared distances between the running per-MG weighted load and configured targets.
- Add `WeeklyPlannedLoad` (in `internal/domain/muscle_group.go`) and `scoreCandidate` (in `internal/domain/planner.go`) as pure helpers.
- Extend `PlanDay` to accept the week's existing load (`weekLoad map[string]float64`) so ad-hoc picks share the same target-awareness; thread that through `internal/service/sessions.go::planSingleDay` / `createAdHocSession` / `StartSession`.
- Remove `allocateMuscleGroups`, `scoreExerciseForPriority`, `findBestExerciseInPool`, `selectAndRemoveFromPool`, the `selectExercisesForDay` wrapper, `hasCategoryExerciseForMuscleGroup`, and the `maxMuscleGroupDaysPerWeek` constant.
- Lowest-exercise-ID tie-break (matches spec) so plans stay deterministic regardless of pool order.

Spec: [`docs/superpowers/specs/2026-05-26-target-aware-planner-design.md`](docs/superpowers/specs/2026-05-26-target-aware-planner-design.md)
Plan: [`docs/superpowers/plans/2026-05-26-target-aware-planner.md`](docs/superpowers/plans/2026-05-26-target-aware-planner.md)

## Behaviour change (Tue/Thu/Sat 90 min profile, real 39-exercise seed)

| MG | Target | Old planner | New planner | Ratio |
|----|-------:|------------:|------------:|------:|
| Chest      | 10 |  8.0 (-20%) | 10.0 | 1.00x |
| Shoulders  | 10 | 17.5 (+75%) | 10.0 | 1.00x |
| Triceps    |  8 | 14.5 (+81%) |  8.5 | 1.06x |
| Biceps     |  8 |  — |  8.0 | 1.00x |
| Upper Back | 10 | 16.5 (+65%) |  9.5 | 0.95x |
| Lats       | 10 |  — | 10.5 | 1.05x |
| Quads      | 10 |  9.0 (-10%) |  9.5 | 0.95x |
| Hamstrings |  8 |  — |  7.0 | 0.88x |
| Glutes     |  8 |  — | 10.0 | 1.25x |

Every targeted MG lands within [0.7x, 1.4x] of target; the regression test `TestPlan_TargetAwareBalanceUnderSeedExercises` asserts that band plus a 1.5x hard ceiling and a Chest >= 8 floor. The original symptom (Chest/Quads undershoot, Shoulders/Triceps/Upper Back overshoot via Phase-B fillers) is resolved.

## Test plan

- [x] `make ci` passes locally (lint 0, race+shuffle tests across all packages green, govulncheck clean)
- [ ] Smoke-check on review app for user 24's schedule (Tue/Thu/Sat 90 min, all FullBody): muscle-balance bar matches the per-MG loads in the table above
- [ ] After merge, watch user 24's next-week regeneration on prod
- [ ] Follow-up after one or two weeks: if any MG still trends outside the target band, recalibrate seed targets in `internal/sqlite/fixtures.sql` rather than re-tuning the algorithm. Likely candidates: adding Abs/Calves/Lower Back targets (currently untargeted MGs accumulate incidental load — Abs sits at 14.0 in the synthetic profile because Plank, Crunch, Rotary Torso, and Ab Wheel all qualify as zero-score fillers) and raising the Glutes target (compound lifts inevitably credit it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)